### PR TITLE
Implement the delay queue for exited thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,12 @@
 - Add a new tool: A debug tool for Trace Profiling is provided for developers to troubleshoot problems.([#363](https://github.com/CloudDectective-Harmonycloud/kindling/pull/363))
 
 ### Bug fixes
+- Implement the delay queue for exited thread, so as to avoid losing the data in the period before the thread exits. ([#365](https://github.com/CloudDectective-Harmonycloud/kindling/pull/365))
 - Fix the bug of incomplete records when threads arrive at the cpu analyzer for the first time. ([#364](https://github.com/CloudDectective-Harmonycloud/kindling/pull/364))
 
 ## v0.5.0 - 2022-11-02
 ### New features
 - Add a new feature: Trace Profiling. See more details about it on our [website](http://kindling.harmonycloud.cn). ([#335](https://github.com/CloudDectective-Harmonycloud/kindling/pull/335))
-
-### Bug fixes
-- Fix the bug of incomplete records when threads arrive at the cpu analyzer for the first time
 
 ### Enhancements
 - Add request and response payload of `Redis` protocol message to `Span` data. ([#325](https://github.com/CloudDectective-Harmonycloud/kindling/pull/325))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 ### New features
 - Add a new feature: Trace Profiling. See more details about it on our [website](http://kindling.harmonycloud.cn). ([#335](https://github.com/CloudDectective-Harmonycloud/kindling/pull/335))
 
+### Bug fixes
+- Fix the bug of incomplete records when threads arrive at the cpu analyzer for the first time
+
 ### Enhancements
 - Add request and response payload of `Redis` protocol message to `Span` data. ([#325](https://github.com/CloudDectective-Harmonycloud/kindling/pull/325))
 

--- a/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
@@ -45,8 +45,8 @@ func NewCpuAnalyzer(cfg interface{}, telemetry *component.TelemetryTools, consum
 		nextConsumers: consumers,
 	}
 	ca.cpuPidEvents = make(map[uint32]map[uint32]*TimeSegments, 100000)
-	ca.InitTidDeleteQueue()
-	go ca.TidDelete(20*time.Second, 10*time.Second)
+	ca.tidExpiredQueue = newTidDeleteQueue()
+	go ca.TidDelete(30*time.Second, 10*time.Second)
 	return ca
 }
 

--- a/collector/pkg/component/analyzer/cpuanalyzer/delete_tid.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/delete_tid.go
@@ -1,0 +1,74 @@
+package cpuanalyzer
+
+import (
+	"sync"
+	"time"
+)
+
+type tidDeleteQueue struct {
+	queueMutex sync.Mutex
+	queue      []deleteTid
+}
+
+type deleteTid struct {
+	pid      uint32
+	tid      uint32
+	exitTime time.Time
+}
+
+func (dq *tidDeleteQueue) GetFront() *deleteTid {
+	if len(dq.queue) > 0 {
+		return &dq.queue[0]
+	}
+	return nil
+}
+
+func (dq *tidDeleteQueue) Push(elem deleteTid) {
+	dq.queue = append(dq.queue, elem)
+}
+
+func (dq *tidDeleteQueue) Pop() {
+	if len(dq.queue) > 0 {
+		dq.queue = dq.queue[1:len(dq.queue)]
+	}
+}
+
+func (ca *CpuAnalyzer) InitTidDeleteQueue() {
+	ca.tidExpiredQueue = &tidDeleteQueue{queue: make([]deleteTid, 0)}
+}
+
+//Add procexit tid
+func (ca *CpuAnalyzer) AddTidToDeleteCache(curTime time.Time, pid uint32, tid uint32) {
+	defer ca.tidExpiredQueue.queueMutex.Unlock()
+	cacheElem := deleteTid{pid: pid, tid: tid, exitTime: curTime}
+	ca.tidExpiredQueue.queueMutex.Lock()
+	ca.tidExpiredQueue.Push(cacheElem)
+}
+
+func (ca *CpuAnalyzer) TidDelete(interval time.Duration, expiredDuration time.Duration) {
+	for {
+		select {
+		case <-time.After(interval):
+			now := time.Now()
+			ca.tidExpiredQueue.queueMutex.Lock()
+			for {
+				elem := ca.tidExpiredQueue.GetFront()
+				if elem == nil {
+					break
+				}
+				if elem.exitTime.Add(expiredDuration).Before(now) {
+					tidEventsMap := ca.cpuPidEvents[elem.pid]
+					if tidEventsMap == nil {
+						continue
+					}
+					ca.telemetry.Logger.Debugf("Delete expired thread... pid=%d, tid=%d", elem.pid, elem.tid)
+					delete(tidEventsMap, elem.tid)
+					ca.tidExpiredQueue.Pop()
+				} else {
+					break
+				}
+			}
+			ca.tidExpiredQueue.queueMutex.Unlock()
+		}
+	}
+}

--- a/collector/pkg/component/analyzer/cpuanalyzer/delete_tid.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/delete_tid.go
@@ -16,6 +16,10 @@ type deleteTid struct {
 	exitTime time.Time
 }
 
+func newTidDeleteQueue() *tidDeleteQueue {
+	return &tidDeleteQueue{queue: make([]deleteTid, 0)}
+}
+
 func (dq *tidDeleteQueue) GetFront() *deleteTid {
 	if len(dq.queue) > 0 {
 		return &dq.queue[0]
@@ -33,15 +37,11 @@ func (dq *tidDeleteQueue) Pop() {
 	}
 }
 
-func (ca *CpuAnalyzer) InitTidDeleteQueue() {
-	ca.tidExpiredQueue = &tidDeleteQueue{queue: make([]deleteTid, 0)}
-}
-
 //Add procexit tid
 func (ca *CpuAnalyzer) AddTidToDeleteCache(curTime time.Time, pid uint32, tid uint32) {
-	defer ca.tidExpiredQueue.queueMutex.Unlock()
 	cacheElem := deleteTid{pid: pid, tid: tid, exitTime: curTime}
 	ca.tidExpiredQueue.queueMutex.Lock()
+	defer ca.tidExpiredQueue.queueMutex.Unlock()
 	ca.tidExpiredQueue.Push(cacheElem)
 }
 

--- a/collector/pkg/component/analyzer/cpuanalyzer/delete_tid.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/delete_tid.go
@@ -71,7 +71,7 @@ func (ca *CpuAnalyzer) TidDelete(interval time.Duration, expiredDuration time.Du
 							continue
 						}
 						ca.telemetry.Logger.Debugf("Delete expired thread... pid=%d, tid=%d", elem.pid, elem.tid)
-
+						//fmt.Printf("Go Test: Delete expired thread... pid=%d, tid=%d\n", elem.pid, elem.tid)
 						ca.DeleteTid(tidEventsMap, elem.tid)
 						ca.tidExpiredQueue.Pop()
 					} else {

--- a/collector/pkg/component/analyzer/cpuanalyzer/delete_tid_test.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/delete_tid_test.go
@@ -1,22 +1,137 @@
 package cpuanalyzer
 
 import (
+	"strconv"
 	"testing"
 	"time"
+
+	"github.com/Kindling-project/kindling/collector/pkg/component"
+)
+
+var (
+	visit    []deleteTid
+	ca       *CpuAnalyzer
+	exitTid  map[uint32]int
+	enterCnt int
+	exitCnt  int
 )
 
 func TestDeleteQueue(t *testing.T) {
 
 	cpupidEvents := make(map[uint32]map[uint32]*TimeSegments, 100000)
-	ca := &CpuAnalyzer{cpuPidEvents: cpupidEvents}
+	testTelemetry := component.NewTelemetryManager().GetGlobalTelemetryTools()
+	ca = &CpuAnalyzer{cpuPidEvents: cpupidEvents, telemetry: testTelemetry}
 
 	ca.tidExpiredQueue = newTidDeleteQueue()
 
-	go ca.TidDelete(3*time.Second, 4*time.Second)
-	for i := 0; i < 10; i++ {
-		ca.AddTidToDeleteCache(time.Now(), uint32(i), uint32(i)+5)
-		t.Logf("pid=%d, tid=%d enter\n", uint32(i), uint32(i)+5)
-		time.Sleep(1 * time.Second)
+	visit = make([]deleteTid, 0)
+	exitTid = make(map[uint32]int, 0)
+
+	go ca.TidDelete(5*time.Second, 4*time.Second)
+	go CheckQueueLoop(t)
+	for i := 0; i < 20; i++ {
+
+		ev := new(CpuEvent)
+		curTime := time.Now()
+		ev.EndTime = uint64(curTime.Add(time.Second).Nanosecond())
+		ev.StartTime = uint64(curTime.Nanosecond())
+
+		//check tid which exist in queue but not in the map
+		if i%4 != 0 {
+			PutElemToMap(uint32(i), uint32(i)+5, "threadname"+strconv.Itoa(i+100), ev)
+		}
+
+		var queueLen int
+
+		func() {
+			ca.tidExpiredQueue.queueMutex.Lock()
+			defer ca.tidExpiredQueue.queueMutex.Unlock()
+			queueLen = len(ca.tidExpiredQueue.queue)
+
+			cacheElem := deleteTid{uint32(i), uint32(i) + 5, curTime.Add(time.Second)}
+			ca.tidExpiredQueue.Push(cacheElem)
+			visit = append(visit, cacheElem)
+			if len(ca.tidExpiredQueue.queue) != queueLen+1 {
+				t.Errorf("the length of queue is not added, expection: %d but: %d\n", queueLen+1, len(ca.tidExpiredQueue.queue))
+			}
+		}()
+
+		t.Logf("pid=%d, tid=%d enter time=%s\n", uint32(i), uint32(i)+5, curTime.Format("2006-01-02 15:04:05"))
+		enterCnt++
+		time.Sleep(3 * time.Second)
+	}
+	time.Sleep(10 * time.Second)
+
+	if enterCnt != exitCnt {
+		t.Fatalf("The number of threads that entering and exiting the queue is not equal! enterCount=%d, exitCount=%d\n", enterCnt, exitCnt)
+	} else {
+		t.Logf("All threads have exited normally. enterCount=%d, exitCount=%d\n", enterCnt, exitCnt)
 	}
 
+}
+
+func CheckQueueLoop(t *testing.T) {
+	for {
+		select {
+		case <-time.After(time.Second * 3):
+			func() {
+				ca.tidExpiredQueue.queueMutex.Lock()
+				defer ca.tidExpiredQueue.queueMutex.Unlock()
+				queueLen := len(ca.tidExpiredQueue.queue)
+				curTime := time.Now()
+				for i := 0; i < len(visit); i++ {
+					tmpv := visit[i]
+					var j int
+					for j = 0; j < queueLen; j++ {
+						tmpq := ca.tidExpiredQueue.queue[j]
+						if tmpv.tid == tmpq.tid {
+							if curTime.After(tmpq.exitTime.Add(12 * time.Second)) {
+								t.Errorf("there is a expired threads that is not deleted. pid=%d, tid=%d, exitTime=%s\n", tmpv.pid, tmpv.tid, tmpv.exitTime.Format("2006-01-02 15:04:05"))
+							}
+							break
+						}
+					}
+
+					if _, exist := exitTid[tmpv.tid]; j >= queueLen && !exist {
+						exitTid[tmpv.tid] = 1
+						exitCnt++
+						t.Logf("pid=%d, tid=%d exit time=%s\n", tmpv.pid, tmpv.tid, curTime.Format("2006-01-02 15:04:05"))
+					}
+				}
+			}()
+		}
+	}
+}
+
+func PutElemToMap(pid uint32, tid uint32, threadName string, event TimedEvent) {
+
+	tidCpuEvents, exist := ca.cpuPidEvents[pid]
+	if !exist {
+		tidCpuEvents = make(map[uint32]*TimeSegments)
+		ca.cpuPidEvents[pid] = tidCpuEvents
+	}
+
+	newTimeSegments := &TimeSegments{
+		Pid:      pid,
+		Tid:      tid,
+		BaseTime: event.StartTimestamp() / nanoToSeconds,
+		Segments: NewCircleQueue(40),
+	}
+	for i := 0; i < 40; i++ {
+		segment := newSegment(pid, tid, threadName,
+			(newTimeSegments.BaseTime+uint64(i))*nanoToSeconds,
+			(newTimeSegments.BaseTime+uint64(i+1))*nanoToSeconds)
+		newTimeSegments.Segments.UpdateByIndex(i, segment)
+	}
+
+	endOffset := int(event.EndTimestamp()/nanoToSeconds - newTimeSegments.BaseTime)
+
+	for i := 0; i <= endOffset && i < 40; i++ {
+		val := newTimeSegments.Segments.GetByIndex(i)
+		segment := val.(*Segment)
+		segment.putTimedEvent(event)
+		segment.IsSend = 0
+	}
+
+	tidCpuEvents[tid] = newTimeSegments
 }

--- a/collector/pkg/component/analyzer/cpuanalyzer/delete_tid_test.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/delete_tid_test.go
@@ -1,0 +1,22 @@
+package cpuanalyzer
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDeleteQueue(t *testing.T) {
+
+	cpupidEvents := make(map[uint32]map[uint32]*TimeSegments, 100000)
+	ca := &CpuAnalyzer{cpuPidEvents: cpupidEvents}
+
+	ca.tidExpiredQueue = newTidDeleteQueue()
+
+	go ca.TidDelete(3*time.Second, 4*time.Second)
+	for i := 0; i < 10; i++ {
+		ca.AddTidToDeleteCache(time.Now(), uint32(i), uint32(i)+5)
+		t.Logf("pid=%d, tid=%d enter\n", uint32(i), uint32(i)+5)
+		time.Sleep(1 * time.Second)
+	}
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implement the delay queue for exited thread.
When the thread exits, it is not destroyed immediately, but cached in the delay queue, so as to avoid losing the data in the period before the thread exits
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->