### PR TITLE
Modify the configuration file structure and add parameter fields for subscription events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - 
 - Support the protocol RocketMQ.([#328](https://github.com/KindlingProject/kindling/pull/328))
 - Add a new tool: A debug tool for Trace Profiling is provided for developers to troubleshoot problems.([#363](https://github.com/CloudDectective-Harmonycloud/kindling/pull/363))
+- Modify the configuration file structure and add parameter fields for subscription events. ([#368](https://github.com/CloudDectective-Harmonycloud/kindling/pull/368))
 
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,12 @@
 
 ## Unreleased
 ### New features
-- 
 - Support the protocol RocketMQ.([#328](https://github.com/KindlingProject/kindling/pull/328))
 - Add a new tool: A debug tool for Trace Profiling is provided for developers to troubleshoot problems.([#363](https://github.com/CloudDectective-Harmonycloud/kindling/pull/363))
-- Modify the configuration file structure and add parameter fields for subscription events. ([#368](https://github.com/CloudDectective-Harmonycloud/kindling/pull/368))
 
 
 ### Enhancements
-- 
+- Modify the configuration file structure and add parameter fields for subscription events. ([#368](https://github.com/CloudDectective-Harmonycloud/kindling/pull/368))
 - 
 - 
 

--- a/collector/pkg/component/receiver/cgoreceiver/cgo_func.h
+++ b/collector/pkg/component/receiver/cgoreceiver/cgo_func.h
@@ -10,7 +10,7 @@ extern "C" {
 #endif
 int runForGo();
 int getKindlingEvent(void **kindlingEvent);
-int subEventForGo(char* eventName, char* category);
+int subEventForGo(char* eventName, char* category, void *params);
 int startProfile();
 int stopProfile();
 void startProfileDebug(int pid, int tid);
@@ -21,6 +21,11 @@ void stopProfileDebug();
 #endif
 
 #endif //SYSDIG_CGO_FUNC_H
+
+struct event_params_for_subscribe {
+	char *name;
+	char *value;
+};
 
 struct kindling_event_t_for_go{
 	uint64_t timestamp;

--- a/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
+++ b/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
@@ -29,6 +29,8 @@ const (
 
 type CKindlingEventForGo C.struct_kindling_event_t_for_go
 
+type CEventParamsForSubscribe C.struct_event_params_for_subscribe
+
 type CgoReceiver struct {
 	cfg             *Config
 	analyzerManager *analyzerpackage.Manager
@@ -172,15 +174,21 @@ func (r *CgoReceiver) sendToNextConsumer(evt *model.KindlingEvent) error {
 	return nil
 }
 
-func (r *CgoReceiver) subEvent() {
+func (r *CgoReceiver) subEvent() error {
 	if len(r.cfg.SubscribeInfo) == 0 {
 		r.telemetry.Logger.Warn("No events are subscribed by cgoreceiver. Please check your configuration.")
 	} else {
 		r.telemetry.Logger.Infof("The subscribed events are: %v", r.cfg.SubscribeInfo)
 	}
 	for _, value := range r.cfg.SubscribeInfo {
-		C.subEventForGo(C.CString(value.Name), C.CString(value.Category))
+		//to do. analyze params filed in the value
+		paramsList := make([]CEventParamsForSubscribe, 0)
+		var temp CEventParamsForSubscribe
+		temp.name = C.CString("terminator")
+		paramsList = append(paramsList, temp)
+		C.subEventForGo(C.CString(value.Name), C.CString(value.Category), (unsafe.Pointer)(&paramsList[0]))
 	}
+	return nil
 }
 
 func (r *CgoReceiver) StartProfile() error {

--- a/collector/pkg/component/receiver/cgoreceiver/config.go
+++ b/collector/pkg/component/receiver/cgoreceiver/config.go
@@ -5,6 +5,7 @@ type Config struct {
 }
 
 type SubEvent struct {
-	Category string `mapstructure:"category"`
-	Name     string `mapstructure:"name"`
+	Category string            `mapstructure:"category"`
+	Name     string            `mapstructure:"name"`
+	Params   map[string]string `mapstructure:"params"`
 }

--- a/probe/src/cgo/cgo_func.cpp
+++ b/probe/src/cgo/cgo_func.cpp
@@ -9,11 +9,11 @@ int runForGo() { return init_probe(); }
 
 int getKindlingEvent(void** kindlingEvent) { return getEvent(kindlingEvent); }
 
-void subEventForGo(char* eventName, char* category) { sub_event(eventName, category); }
 
 int startProfile() { return start_profile(); }
 int stopProfile() { return stop_profile(); }
 
+void subEventForGo(char* eventName, char* category, void *params) { sub_event(eventName, category, (event_params_for_subscribe *)params); }
 void startProfileDebug(int pid, int tid) { start_profile_debug(pid, tid); }
 
 void stopProfileDebug() { stop_profile_debug(); }

--- a/probe/src/cgo/cgo_func.h
+++ b/probe/src/cgo/cgo_func.h
@@ -10,7 +10,7 @@ extern "C" {
 #endif
 int runForGo();
 int getKindlingEvent(void** kindlingEvent);
-void subEventForGo(char* eventName, char* category);
+void subEventForGo(char* eventName, char* category, void* params);
 int startProfile();
 int stopProfile();
 void startProfileDebug(int pid, int tid);

--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -55,7 +55,7 @@ void init_sub_label() {
   }
 }
 
-void sub_event(char* eventName, char* category) {
+void sub_event(char* eventName, char* category, event_params_for_subscribe params[]) {
   auto it_type = m_events.find(eventName);
   if (it_type == m_events.end()) {
     cout << "failed to find event " << eventName << endl;

--- a/probe/src/cgo/kindling.h
+++ b/probe/src/cgo/kindling.h
@@ -30,8 +30,6 @@ uint16_t get_kindling_category(sinsp_evt* sEvt);
 
 void init_sub_label();
 
-void sub_event(char* eventName, char* category);
-
 int start_profile();
 
 int stop_profile();
@@ -51,6 +49,11 @@ struct event {
   string event_name;
   ppm_event_type event_type;
 };
+struct event_params_for_subscribe {
+  char *name;
+  char *value;
+};
+void sub_event(char* eventName, char* category, event_params_for_subscribe params[]);
 struct kindling_event_t_for_go {
   uint64_t timestamp;
   char* name;


### PR DESCRIPTION
Modify the configuration file structure and add parameter fields for subscription events

Signed-off-by: yaofighting <siyao@zju.edu.cn>

### Motivation
In some scenarios, only specifying the type of subscription event cannot meet our needs. Therefore, we need to enhance the features of the subscription part, support more detailed parameter lists, and control the CPP side to send only the event information we are concerned about to the Go side. For example, we need to specify system calls that filter latency is less than 500ms. When subscribing to events, we tell the CPP side to send only data that meets this condition, so as to avoid performance loss caused by data filtering on the Go side.
## Related Issue
#366 