### PR TITLE
Fix the pod info with persistent IP in the map is deleted incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - 
 
 ### Bug fixes
-- 
+- Fix the bug where the pod metadata with persistent IP in the map is deleted incorrectly due to the deleting mechanism with a delay. ([#374](https://github.com/KindlingProject/kindling/pull/374))
 - 
 - 
 - Fix the bug that cpuEvent cache size continuously increases even if trace profiling is not enabled.([#362](https://github.com/CloudDectective-Harmonycloud/kindling/pull/362))

--- a/collector/pkg/metadata/kubernetes/k8scache.go
+++ b/collector/pkg/metadata/kubernetes/k8scache.go
@@ -14,6 +14,7 @@ type K8sContainerInfo struct {
 }
 
 type K8sPodInfo struct {
+	UID          string
 	Ip           string
 	PodName      string
 	Ports        []int32

--- a/collector/pkg/metadata/kubernetes/pod_delete.go
+++ b/collector/pkg/metadata/kubernetes/pod_delete.go
@@ -20,6 +20,7 @@ type deleteRequest struct {
 }
 
 type deletedPodInfo struct {
+	UID          string
 	name         string
 	namespace    string
 	containerIds []string
@@ -65,18 +66,32 @@ func deletePodInfo(podInfo *deletedPodInfo) {
 	}
 	if len(podInfo.containerIds) != 0 {
 		for i := 0; i < len(podInfo.containerIds); i++ {
+			// Assume that container id can't be reused in a few seconds
 			MetaDataCache.DeleteByContainerId(podInfo.containerIds[i])
 		}
 	}
 	if podInfo.ip != "" && len(podInfo.ports) != 0 {
 		for _, port := range podInfo.ports {
-			// Assume that PodIP:Port can't be reused in a few seconds
-			MetaDataCache.DeleteContainerByIpPort(podInfo.ip, uint32(port))
+			containerInfo, ok := MetaDataCache.GetContainerByIpPort(podInfo.ip, uint32(port))
+			if !ok {
+				continue
+			}
+			// PodIP:Port can be reused in a few seconds, so we check its UID
+			if containerInfo.RefPodInfo.UID == podInfo.UID {
+				MetaDataCache.DeleteContainerByIpPort(podInfo.ip, uint32(port))
+			}
 		}
 	}
 	if podInfo.hostIp != "" && len(podInfo.hostPorts) != 0 {
 		for _, port := range podInfo.hostPorts {
-			MetaDataCache.DeleteContainerByHostIpPort(podInfo.hostIp, uint32(port))
+			containerInfo, ok := MetaDataCache.GetContainerByHostIpPort(podInfo.ip, uint32(port))
+			if !ok {
+				continue
+			}
+			// PodIP:Port can be reused in a few seconds, so we check its UID
+			if containerInfo.RefPodInfo.UID == podInfo.UID {
+				MetaDataCache.DeleteContainerByHostIpPort(podInfo.ip, uint32(port))
+			}
 		}
 	}
 }

--- a/collector/pkg/metadata/kubernetes/pod_delete.go
+++ b/collector/pkg/metadata/kubernetes/pod_delete.go
@@ -20,7 +20,7 @@ type deleteRequest struct {
 }
 
 type deletedPodInfo struct {
-	UID          string
+	uid          string
 	name         string
 	namespace    string
 	containerIds []string
@@ -77,20 +77,20 @@ func deletePodInfo(podInfo *deletedPodInfo) {
 				continue
 			}
 			// PodIP:Port can be reused in a few seconds, so we check its UID
-			if containerInfo.RefPodInfo.UID == podInfo.UID {
+			if containerInfo.RefPodInfo.UID == podInfo.uid {
 				MetaDataCache.DeleteContainerByIpPort(podInfo.ip, uint32(port))
 			}
 		}
 	}
 	if podInfo.hostIp != "" && len(podInfo.hostPorts) != 0 {
 		for _, port := range podInfo.hostPorts {
-			containerInfo, ok := MetaDataCache.GetContainerByHostIpPort(podInfo.ip, uint32(port))
+			containerInfo, ok := MetaDataCache.GetContainerByHostIpPort(podInfo.hostIp, uint32(port))
 			if !ok {
 				continue
 			}
 			// PodIP:Port can be reused in a few seconds, so we check its UID
-			if containerInfo.RefPodInfo.UID == podInfo.UID {
-				MetaDataCache.DeleteContainerByHostIpPort(podInfo.ip, uint32(port))
+			if containerInfo.RefPodInfo.UID == podInfo.uid {
+				MetaDataCache.DeleteContainerByHostIpPort(podInfo.hostIp, uint32(port))
 			}
 		}
 	}

--- a/collector/pkg/metadata/kubernetes/pod_watch.go
+++ b/collector/pkg/metadata/kubernetes/pod_watch.go
@@ -253,6 +253,7 @@ func OnUpdate(objOld interface{}, objNew interface{}) {
 
 	// Delay delete the pod using the difference between the old pod and the new one
 	deletedPodInfo := &deletedPodInfo{
+		uid:          string(oldPod.UID),
 		name:         "",
 		namespace:    oldPod.Namespace,
 		containerIds: nil,
@@ -324,7 +325,7 @@ func OnUpdate(objOld interface{}, objNew interface{}) {
 func onDelete(obj interface{}) {
 	pod := obj.(*corev1.Pod)
 	podInfo := &deletedPodInfo{
-		UID:          string(pod.UID),
+		uid:          string(pod.UID),
 		name:         pod.Name,
 		namespace:    pod.Namespace,
 		containerIds: make([]string, 0),

--- a/collector/pkg/metadata/kubernetes/pod_watch.go
+++ b/collector/pkg/metadata/kubernetes/pod_watch.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Kindling-project/kindling/collector/pkg/compare"
 	corev1 "k8s.io/api/core/v1"
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -16,6 +15,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 	_ "k8s.io/client-go/tools/clientcmd"
 	_ "k8s.io/client-go/util/homedir"
+
+	"github.com/Kindling-project/kindling/collector/pkg/compare"
 )
 
 type podMap struct {
@@ -141,6 +142,7 @@ func onAdd(obj interface{}) {
 	}
 
 	var cachePodInfo = &K8sPodInfo{
+		UID:           string(pod.UID),
 		Ip:            pod.Status.PodIP,
 		Namespace:     pod.Namespace,
 		PodName:       pod.Name,
@@ -322,6 +324,7 @@ func OnUpdate(objOld interface{}, objNew interface{}) {
 func onDelete(obj interface{}) {
 	pod := obj.(*corev1.Pod)
 	podInfo := &deletedPodInfo{
+		UID:          string(pod.UID),
 		name:         pod.Name,
 		namespace:    pod.Namespace,
 		containerIds: make([]string, 0),

--- a/collector/pkg/metadata/kubernetes/pod_watch_test.go
+++ b/collector/pkg/metadata/kubernetes/pod_watch_test.go
@@ -335,6 +335,6 @@ func assertFindPod(t *testing.T, pod *corev1.Pod) {
 	assert.True(t, find, "Didn't find the new container ID in MetaDataCache")
 	_, find = MetaDataCache.GetContainerByIpPort(pod.Status.PodIP, uint32(pod.Spec.Containers[0].Ports[0].ContainerPort))
 	assert.True(t, find, "Didn't find the new container IP Port in MetaDataCache")
-	_, find = MetaDataCache.GetContainerByHostIpPort(pod.Status.HostIP, uint32(pod.Spec.Containers[0].Ports[0].ContainerPort))
+	_, find = MetaDataCache.GetContainerByHostIpPort(pod.Status.HostIP, uint32(pod.Spec.Containers[0].Ports[0].HostPort))
 	assert.True(t, find, "Didn't find the new HostIP Port in MetaDataCache")
 }

--- a/collector/pkg/metadata/kubernetes/pod_watch_test.go
+++ b/collector/pkg/metadata/kubernetes/pod_watch_test.go
@@ -148,6 +148,7 @@ func TestOnAddLowercaseWorkload(t *testing.T) {
 func CreatePod(hasPort bool) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
+			UID:       "0ae5c03d-5fb3-4eb9-9de8-2bd4b51606ba",
 			Name:      "deploy-1a2b3c4d-5e6f7",
 			Namespace: "CustomNamespace",
 			Labels: map[string]string{
@@ -197,8 +198,8 @@ func CreatePod(hasPort bool) *corev1.Pod {
 }
 
 func TestUpdateAndDelayDelete(t *testing.T) {
-	addObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"resourceVersion\":\"44895976\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9001,\"protocol\":\"TCP\",\"hostPort\":9001}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.210\",\"hostIP\":\"10.10.10.101\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d505f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
-	updateObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"resourceVersion\":\"44895977\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9001,\"protocol\":\"TCP\",\"hostPort\":9001}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.212\",\"hostIP\":\"10.10.10.102\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d000f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
+	addObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"uid\":\"0ae5c03d-5fb3-4eb9-9de8-2bd4b51606ba\",\"resourceVersion\":\"44895976\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9001,\"protocol\":\"TCP\",\"hostPort\":9001}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.210\",\"hostIP\":\"10.10.10.101\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d505f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
+	updateObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"uid\":\"0ae5c03d-5fb3-4eb9-9de8-2bd4b51606ba\",\"resourceVersion\":\"44895977\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9001,\"protocol\":\"TCP\",\"hostPort\":9001}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.212\",\"hostIP\":\"10.10.10.102\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d000f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
 	addObj := new(corev1.Pod)
 	err := json.Unmarshal([]byte(addObjJson), addObj)
 	if err != nil {
@@ -215,34 +216,20 @@ func TestUpdateAndDelayDelete(t *testing.T) {
 	_, ok := MetaDataCache.GetContainerByIpPort(podIp, uint32(port))
 	if !ok {
 		t.Fatalf("Not found container [%s:%d]", podIp, port)
-	} else {
-		t.Logf("Found container [%s:%d]", podIp, port)
 	}
 	stopCh := make(chan struct{})
 	go podDeleteLoop(100*time.Millisecond, 500*time.Millisecond, stopCh)
 	OnUpdate(addObj, updateObj)
 
-	// Check if new Container can be find
-	_, find := MetaDataCache.GetByContainerId(TruncateContainerId(updateObj.Status.ContainerStatuses[0].ContainerID))
-	assert.True(t, find, "NewContainerId did't find in MetaDataCache")
-	_, find = MetaDataCache.GetContainerByIpPort(updateObj.Status.PodIP, uint32(port))
-	assert.True(t, find, "NewContainer IP Port did't find in MetaDataCache")
-	_, find = MetaDataCache.GetContainerByHostIpPort(updateObj.Status.HostIP, uint32(port))
-	assert.True(t, find, "NewHostIp Port did't find in MetaDataCache")
-
-	// Wait for deletes
+	// Check if the new container can be found
+	assertFindPod(t, updateObj)
+	// Wait for the deleting
 	time.Sleep(1000 * time.Millisecond)
+	// Double check for the new container
+	assertFindPod(t, updateObj)
 
-	// Double Check for NewContainer
-	_, find = MetaDataCache.GetByContainerId(TruncateContainerId(updateObj.Status.ContainerStatuses[0].ContainerID))
-	assert.True(t, find, "NewContainerId did't find in MetaDataCache")
-	_, find = MetaDataCache.GetContainerByIpPort(updateObj.Status.PodIP, uint32(port))
-	assert.True(t, find, "NewContainer IP Port did't find in MetaDataCache")
-	_, find = MetaDataCache.GetContainerByHostIpPort(updateObj.Status.HostIP, uint32(port))
-	assert.True(t, find, "NewHostIp Port did't find in MetaDataCache")
-
-	// Check the old Container has been delete
-	_, find = MetaDataCache.GetByContainerId(TruncateContainerId(addObj.Status.ContainerStatuses[0].ContainerID))
+	// Check if the old container has been deleted
+	_, find := MetaDataCache.GetByContainerId(TruncateContainerId(addObj.Status.ContainerStatuses[0].ContainerID))
 	assert.False(t, find, "OldContainerId should be deletedin MetaDataCache")
 	_, find = MetaDataCache.GetContainerByIpPort(addObj.Status.PodIP, uint32(port))
 	assert.False(t, find, "OldContainer IP should be deleted in MetaDataCache")
@@ -253,40 +240,29 @@ func TestUpdateAndDelayDelete(t *testing.T) {
 }
 
 func TestUpdateAndDelayDeleteWhenOnlyPodIpChanged(t *testing.T) {
-	addObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"resourceVersion\":\"44895976\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9001,\"protocol\":\"TCP\",\"hostPort\":9001}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.210\",\"hostIP\":\"10.10.10.101\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d505f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
-	updateObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"resourceVersion\":\"44895977\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9001,\"protocol\":\"TCP\",\"hostPort\":9001}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.212\",\"hostIP\":\"10.10.10.101\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d000f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
+	addObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"uid\":\"0ae5c03d-5fb3-4eb9-9de8-2bd4b51606ba\",\"resourceVersion\":\"44895976\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9001,\"protocol\":\"TCP\",\"hostPort\":9001}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.210\",\"hostIP\":\"10.10.10.101\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d505f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
+	updateObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"uid\":\"0ae5c03d-5fb3-4eb9-9de8-2bd4b51606ba\",\"resourceVersion\":\"44895977\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9001,\"protocol\":\"TCP\",\"hostPort\":9001}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.212\",\"hostIP\":\"10.10.10.101\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d000f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
 	addObj := new(corev1.Pod)
-	json.Unmarshal([]byte(addObjJson), addObj)
+	_ = json.Unmarshal([]byte(addObjJson), addObj)
 	updateObj := new(corev1.Pod)
-	json.Unmarshal([]byte(updateObjJson), updateObj)
-	port := addObj.Spec.Containers[0].Ports[0].ContainerPort
+	_ = json.Unmarshal([]byte(updateObjJson), updateObj)
+
 	onAdd(addObj)
 	stopCh := make(chan struct{})
 	go podDeleteLoop(100*time.Millisecond, 500*time.Millisecond, stopCh)
 	OnUpdate(addObj, updateObj)
 
-	// Check if new Container can be find
-	_, find := MetaDataCache.GetByContainerId(TruncateContainerId(updateObj.Status.ContainerStatuses[0].ContainerID))
-	assert.True(t, find, "NewContainerId did't find in MetaDataCache")
-	_, find = MetaDataCache.GetContainerByIpPort(updateObj.Status.PodIP, uint32(port))
-	assert.True(t, find, "NewContainer IP Port did't find in MetaDataCache")
-	_, find = MetaDataCache.GetContainerByHostIpPort(updateObj.Status.HostIP, uint32(port))
-	assert.True(t, find, "NewHostIp Port did't find in MetaDataCache")
-
-	// Wait for deletes
+	// Check if the new container can be found
+	assertFindPod(t, updateObj)
+	// Wait for the deleting
 	time.Sleep(1000 * time.Millisecond)
+	// Double check for the new container
+	assertFindPod(t, updateObj)
 
-	// Double Check for NewContainer
-	_, find = MetaDataCache.GetByContainerId(TruncateContainerId(updateObj.Status.ContainerStatuses[0].ContainerID))
-	assert.True(t, find, "NewContainerId did't find in MetaDataCache")
-	_, find = MetaDataCache.GetContainerByIpPort(updateObj.Status.PodIP, uint32(port))
-	assert.True(t, find, "NewContainer IP Port did't find in MetaDataCache")
-	_, find = MetaDataCache.GetContainerByHostIpPort(updateObj.Status.HostIP, uint32(port))
-	assert.True(t, find, "NewHostIp Port did't find in MetaDataCache")
-
-	// Check the old Container has been delete
-	_, find = MetaDataCache.GetByContainerId(TruncateContainerId(addObj.Status.ContainerStatuses[0].ContainerID))
-	assert.False(t, find, "OldContainerId should be deletedin MetaDataCache")
+	// Check if the old container has been deleted
+	port := addObj.Spec.Containers[0].Ports[0].ContainerPort
+	_, find := MetaDataCache.GetByContainerId(TruncateContainerId(addObj.Status.ContainerStatuses[0].ContainerID))
+	assert.False(t, find, "OldContainerId should be deleted in MetaDataCache")
 	_, find = MetaDataCache.GetContainerByIpPort(addObj.Status.PodIP, uint32(port))
 	assert.False(t, find, "OldContainer IP should be deleted in MetaDataCache")
 
@@ -294,45 +270,42 @@ func TestUpdateAndDelayDeleteWhenOnlyPodIpChanged(t *testing.T) {
 }
 
 func TestUpdateAndDelayDeleteWhenOnlyPortChanged(t *testing.T) {
-	addObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"resourceVersion\":\"44895976\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9001,\"protocol\":\"TCP\",\"hostPort\":9001}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.210\",\"hostIP\":\"10.10.10.101\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d505f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
-	updateObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"resourceVersion\":\"44895977\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9002,\"protocol\":\"TCP\",\"hostPort\":9002}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.210\",\"hostIP\":\"10.10.10.101\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d000f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
+	addObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"uid\":\"0ae5c03d-5fb3-4eb9-9de8-2bd4b51606ba\",\"resourceVersion\":\"44895976\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9001,\"protocol\":\"TCP\",\"hostPort\":9001}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.210\",\"hostIP\":\"10.10.10.101\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d505f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
+	updateObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"uid\":\"0ae5c03d-5fb3-4eb9-9de8-2bd4b51606ba\",\"resourceVersion\":\"44895977\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9002,\"protocol\":\"TCP\",\"hostPort\":9002}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.210\",\"hostIP\":\"10.10.10.101\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d000f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
 	addObj := new(corev1.Pod)
-	json.Unmarshal([]byte(addObjJson), addObj)
+	_ = json.Unmarshal([]byte(addObjJson), addObj)
 	updateObj := new(corev1.Pod)
-	json.Unmarshal([]byte(updateObjJson), updateObj)
-	port := addObj.Spec.Containers[0].Ports[0].ContainerPort
-	newPort := updateObj.Spec.Containers[0].Ports[0].ContainerPort
+	_ = json.Unmarshal([]byte(updateObjJson), updateObj)
+
 	onAdd(addObj)
 	stopCh := make(chan struct{})
 	go podDeleteLoop(100*time.Millisecond, 500*time.Millisecond, stopCh)
 	OnUpdate(addObj, updateObj)
 
-	// Check if new Container can be find
-	_, find := MetaDataCache.GetByContainerId(TruncateContainerId(updateObj.Status.ContainerStatuses[0].ContainerID))
-	assert.True(t, find, "NewContainerId did't find in MetaDataCache")
-	_, find = MetaDataCache.GetContainerByIpPort(updateObj.Status.PodIP, uint32(newPort))
-	assert.True(t, find, "NewContainer IP Port did't find in MetaDataCache")
-	_, find = MetaDataCache.GetContainerByHostIpPort(updateObj.Status.HostIP, uint32(newPort))
-	assert.True(t, find, "NewHostIp Port did't find in MetaDataCache")
-
-	// Wait for deletes
+	// Check if new container can be found
+	assertFindPod(t, updateObj)
+	// Wait for the deleting
 	time.Sleep(1000 * time.Millisecond)
+	// Double check for the new container
+	assertFindPod(t, updateObj)
 
-	// Double Check for NewContainer
-	_, find = MetaDataCache.GetByContainerId(TruncateContainerId(updateObj.Status.ContainerStatuses[0].ContainerID))
-	assert.True(t, find, "NewContainerId did't find in MetaDataCache")
-	_, find = MetaDataCache.GetContainerByIpPort(updateObj.Status.PodIP, uint32(newPort))
-	assert.True(t, find, "NewContainer IP Port did't find in MetaDataCache")
-	_, find = MetaDataCache.GetContainerByHostIpPort(updateObj.Status.HostIP, uint32(newPort))
-	assert.True(t, find, "NewHostIp Port did't find in MetaDataCache")
-
-	// Check the old Container has been delete
-	_, find = MetaDataCache.GetByContainerId(TruncateContainerId(addObj.Status.ContainerStatuses[0].ContainerID))
-	assert.False(t, find, "OldContainerId should be deletedin MetaDataCache")
+	// Check the old Container has been deleted
+	port := addObj.Spec.Containers[0].Ports[0].ContainerPort
+	_, find := MetaDataCache.GetByContainerId(TruncateContainerId(addObj.Status.ContainerStatuses[0].ContainerID))
+	assert.False(t, find, "OldContainerId should be deleted in MetaDataCache")
 	_, find = MetaDataCache.GetContainerByIpPort(addObj.Status.PodIP, uint32(port))
-	assert.True(t, find, "If podIp is not changed , Old IP can still be found in MetaDataCache")
+	assert.True(t, find, "If podIp is not changed, Old IP can still be found in MetaDataCache")
 	_, find = MetaDataCache.GetContainerByHostIpPort(addObj.Status.HostIP, uint32(port))
 	assert.False(t, find, "OldHostIp Port should be deleted in MetaDataCache")
 
 	stopCh <- struct{}{}
+}
+
+func assertFindPod(t *testing.T, pod *corev1.Pod) {
+	_, find := MetaDataCache.GetByContainerId(TruncateContainerId(pod.Status.ContainerStatuses[0].ContainerID))
+	assert.True(t, find, "Didn't find the new container ID in MetaDataCache")
+	_, find = MetaDataCache.GetContainerByIpPort(pod.Status.PodIP, uint32(pod.Spec.Containers[0].Ports[0].ContainerPort))
+	assert.True(t, find, "Didn't find the new container IP Port in MetaDataCache")
+	_, find = MetaDataCache.GetContainerByHostIpPort(pod.Status.HostIP, uint32(pod.Spec.Containers[0].Ports[0].ContainerPort))
+	assert.True(t, find, "Didn't find the new HostIP Port in MetaDataCache")
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
We have implemented a mechanism to delete the pod metadata with a delay. We assumed the pod IP couldn't be reused in a short time, but in fact, IP addresses can be persistent in Kubernetes. If a pod is deleted and then a pod with the same IP is created, the delayed deletion will remove this new pod metadata from the cache map, in which case we can't find the pod information when processing data.

Since the UID of pods can identify a unique pod, I added it as a field of the `K8sPodInfo` struct. When the delayed deletion mechanism runs, only the pods with the same UID as the deletion requests are removed. This makes sure only those pods whose UIDs are not overwritten by new pods are deleted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
=== RUN   TestUpdateAndDelayDelete
--- PASS: TestUpdateAndDelayDelete (1.00s)
=== RUN   TestUpdateAndDelayDeleteWhenOnlyPodIpChanged
--- PASS: TestUpdateAndDelayDeleteWhenOnlyPodIpChanged (1.00s)
=== RUN   TestUpdateAndDelayDeleteWhenOnlyPortChanged
--- PASS: TestUpdateAndDelayDeleteWhenOnlyPortChanged (1.00s)
=== RUN   TestDelayDeleteThenAddWithSameIP
--- PASS: TestDelayDeleteThenAddWithSameIP (0.20s)
```