### PR TITLE
Add payload for all protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 
 ### Enhancements
-- 
+- Add payload for all protocols.([#375](https://github.com/KindlingProject/kindling/pull/375))
 - 
 - 
 

--- a/collector/pkg/component/analyzer/network/network_analyzer_test.go
+++ b/collector/pkg/component/analyzer/network/network_analyzer_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Kindling-project/kindling/collector/pkg/component"
+	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer/network/protocol"
 	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer/network/protocol/factory"
 	"github.com/Kindling-project/kindling/collector/pkg/component/consumer"
 	"github.com/Kindling-project/kindling/collector/pkg/model"
@@ -91,6 +92,17 @@ func prepareNetworkAnalyzer() *NetworkAnalyzer {
 			dataGroupPool: NewDataGroupPool(),
 			nextConsumers: []consumer.Consumer{&NopProcessor{}},
 			telemetry:     component.NewDefaultTelemetryTools(),
+		}
+		na.staticPortMap = map[uint32]string{}
+		for _, config := range na.cfg.ProtocolConfigs {
+			for _, port := range config.Ports {
+				na.staticPortMap[port] = config.Key
+			}
+		}
+		na.slowThresholdMap = map[string]int{}
+		for _, config := range na.cfg.ProtocolConfigs {
+			protocol.SetPayLoadLength(config.Key, config.PayloadLength)
+			na.slowThresholdMap[config.Key] = config.Threshold
 		}
 		na.parserFactory = factory.NewParserFactory(factory.WithUrlClusteringMethod(na.cfg.UrlClusteringMethod))
 		na.Start()

--- a/collector/pkg/component/analyzer/network/network_analyzer_test.go
+++ b/collector/pkg/component/analyzer/network/network_analyzer_test.go
@@ -298,11 +298,11 @@ func (evt *TraceEvent) exchange(common *EventCommon) *model.KindlingEvent {
 	modelEvt := &model.KindlingEvent{
 		Source:       model.Source(common.Source),
 		Timestamp:    evt.Timestamp,
+		Latency:      uint64(evt.UserAttributes.Latency),
 		Name:         evt.Name,
 		Category:     model.Category(common.Category),
 		ParamsNumber: 3,
 		UserAttributes: [16]model.KeyValue{
-			{Key: "latency", ValueType: model.ValueType_UINT64, Value: Int64ToBytes(evt.UserAttributes.Latency)},
 			{Key: "res", ValueType: model.ValueType_INT64, Value: Int64ToBytes(evt.UserAttributes.Res)},
 			{Key: "data", ValueType: model.ValueType_BYTEBUF, Value: byteData},
 		},

--- a/collector/pkg/component/analyzer/network/protocol/dubbo/dubbo_parser.go
+++ b/collector/pkg/component/analyzer/network/protocol/dubbo/dubbo_parser.go
@@ -17,34 +17,10 @@ const (
 	FlagTwoWay  = byte(0x40)
 	FlagEvent   = byte(0x20) // for heartbeat
 	SerialMask  = 0x1f
-
-	AsciiLow     = byte(0x20)
-	AsciiHigh    = byte(0x7e)
-	AsciiReplace = byte(0x2e) // .
 )
 
 func NewDubboParser() *protocol.ProtocolParser {
 	requestParser := protocol.CreatePkgParser(fastfailDubboRequest(), parseDubboRequest())
 	responseParser := protocol.CreatePkgParser(fastfailDubboResponse(), parseDubboResponse())
 	return protocol.NewProtocolParser(protocol.DUBBO, requestParser, responseParser, nil)
-}
-
-/**
-  Get the ascii readable string, replace other value to '.', like wireshark.
-*/
-func getAsciiString(data []byte) string {
-	length := len(data)
-	if length == 0 {
-		return ""
-	}
-
-	newData := make([]byte, length)
-	for i := 0; i < length; i++ {
-		if data[i] > AsciiHigh || data[i] < AsciiLow {
-			newData[i] = AsciiReplace
-		} else {
-			newData[i] = data[i]
-		}
-	}
-	return string(newData)
 }

--- a/collector/pkg/component/analyzer/network/protocol/dubbo/dubbo_request.go
+++ b/collector/pkg/component/analyzer/network/protocol/dubbo/dubbo_request.go
@@ -19,7 +19,6 @@ func parseDubboRequest() protocol.ParsePkgFn {
 		}
 
 		message.AddStringAttribute(constlabels.ContentKey, contentKey)
-		message.AddStringAttribute(constlabels.RequestPayload, getAsciiString(message.GetData(16, protocol.GetDubboPayLoadLength())))
 		return true, true
 	}
 }

--- a/collector/pkg/component/analyzer/network/protocol/dubbo/dubbo_response.go
+++ b/collector/pkg/component/analyzer/network/protocol/dubbo/dubbo_response.go
@@ -23,7 +23,6 @@ func parseDubboResponse() protocol.ParsePkgFn {
 			message.AddBoolAttribute(constlabels.IsError, true)
 			message.AddIntAttribute(constlabels.ErrorType, int64(constlabels.ProtocolError))
 		}
-		message.AddStringAttribute(constlabels.ResponsePayload, getAsciiString(message.GetData(16, protocol.GetDubboPayLoadLength())))
 		return true, true
 	}
 }

--- a/collector/pkg/component/analyzer/network/protocol/http/http_parser_test.go
+++ b/collector/pkg/component/analyzer/network/protocol/http/http_parser_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer/network/protocol"
-	"github.com/Kindling-project/kindling/collector/pkg/model"
-	"github.com/Kindling-project/kindling/collector/pkg/model/constlabels"
 )
 
 func Test_urlMerge(t *testing.T) {
@@ -78,101 +76,6 @@ func TestHttpParser_getContentKey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := getContentKey(tt.args.url); got != tt.want {
 				t.Errorf("getContentKey() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestParseHttpRequest_GetPayLoad(t *testing.T) {
-	type args struct {
-		message *protocol.PayloadMessage
-	}
-	httpData := "POST /test?sleep=0&respbyte=1000&statusCode=200 HTTP/1.1\r\nKey1: value1\r\n\r\nHello world"
-
-	tests := []struct {
-		name string
-		size int
-		want string
-	}{
-		{name: "substring", size: 10, want: "POST /test"},
-		{name: "equal", size: 85, want: httpData},
-		{name: "overflow", size: 100, want: httpData},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			protocol.SetPayLoadLength(protocol.HTTP, tt.size)
-			message := protocol.NewRequestMessage([]byte(httpData))
-			NewHttpParser("").ParseRequest(message)
-
-			if !message.HasAttribute(constlabels.RequestPayload) {
-				t.Errorf("Fail to parse HttpRequest()")
-			}
-			if got := message.GetStringAttribute(constlabels.RequestPayload); got != tt.want {
-				t.Errorf("GetHttpPayload() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-
-	tests2 := []struct {
-		name string
-		args args
-		size int
-		want map[string]string
-	}{
-		{
-			name: "normal case",
-			args: args{
-				message: protocol.NewRequestMessage([]byte("HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nAPM-AgentID: TTXvC3EQS6KLwxx3eIqINFjAW2olRm+cr8M+yuvwhkY=\r\nTransfer-Encoding: chunked\r\nContent-Type: application/json\r\nAPM-TransactionID: 5e480579c718a4a6498a9")),
-			},
-			want: map[string]string{
-				"connection":        "keep-alive",
-				"apm-agentid":       "TTXvC3EQS6KLwxx3eIqINFjAW2olRm+cr8M+yuvwhkY=",
-				"transfer-encoding": "chunked",
-				"content-type":      "application/json",
-				"apm-transactionid": "5e480579c718a4a6498a9",
-			},
-		},
-		{
-			name: "no values",
-			args: args{
-				protocol.NewRequestMessage([]byte("HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nTransfer-Encoding: ")),
-			},
-			want: map[string]string{
-				"connection": "keep-alive",
-			},
-		},
-		{
-
-			name: "no spaces",
-			args: args{
-				protocol.NewRequestMessage([]byte("HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nTransfer-Encoding:")),
-			},
-			want: map[string]string{
-				"connection": "keep-alive",
-			},
-		},
-		{
-			name: "no colon",
-			args: args{
-				protocol.NewRequestMessage([]byte("HTTP/1.1 200 OK\r\nConnection: keep-alive\r\nTransfer-Encoding")),
-			},
-			want: map[string]string{
-				"connection": "keep-alive",
-			},
-		},
-	}
-	for _, tt := range tests2 {
-		t.Run(tt.name, func(t *testing.T) {
-			protocol.SetPayLoadLength(protocol.HTTP, tt.size)
-
-			message := protocol.NewResponseMessage([]byte(httpData), model.NewAttributeMap())
-			NewHttpParser("").ParseResponse(message)
-
-			if !message.HasAttribute(constlabels.ResponsePayload) {
-				t.Errorf("Fail to parse HttpResponse()")
-			}
-			if got := message.GetStringAttribute(constlabels.ResponsePayload); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetHttpPayload() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/collector/pkg/component/analyzer/network/protocol/http/http_parser_test.go
+++ b/collector/pkg/component/analyzer/network/protocol/http/http_parser_test.go
@@ -84,6 +84,9 @@ func TestHttpParser_getContentKey(t *testing.T) {
 }
 
 func TestParseHttpRequest_GetPayLoad(t *testing.T) {
+	type args struct {
+		message *protocol.PayloadMessage
+	}
 	httpData := "POST /test?sleep=0&respbyte=1000&statusCode=200 HTTP/1.1\r\nKey1: value1\r\n\r\nHello world"
 
 	tests := []struct {
@@ -109,9 +112,11 @@ func TestParseHttpRequest_GetPayLoad(t *testing.T) {
 			}
 		})
 	}
-	tests := []struct {
+
+	tests2 := []struct {
 		name string
 		args args
+		size int
 		want map[string]string
 	}{
 		{
@@ -156,7 +161,7 @@ func TestParseHttpRequest_GetPayLoad(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for _, tt := range tests2 {
 		t.Run(tt.name, func(t *testing.T) {
 			protocol.SetPayLoadLength(protocol.HTTP, tt.size)
 
@@ -166,7 +171,7 @@ func TestParseHttpRequest_GetPayLoad(t *testing.T) {
 			if !message.HasAttribute(constlabels.ResponsePayload) {
 				t.Errorf("Fail to parse HttpResponse()")
 			}
-			if got := message.GetStringAttribute(constlabels.ResponsePayload); got != tt.want {
+			if got := message.GetStringAttribute(constlabels.ResponsePayload); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetHttpPayload() = %v, want %v", got, tt.want)
 			}
 		})

--- a/collector/pkg/component/analyzer/network/protocol/http/http_request.go
+++ b/collector/pkg/component/analyzer/network/protocol/http/http_request.go
@@ -18,12 +18,14 @@ func fastfailHttpRequest() protocol.FastFailFn {
 
 /*
 Request line
-    Method [GET/POST/PUT/DELETE/HEAD/TRACE/OPTIONS/CONNECT]
-	Blank
-	Request-URI [eg. /xxx/yyy?parm0=aaa&param1=bbb]
-	Blank
-	HTTP-Version [HTTP/1.0 | HTTP/1.2]
-	\r\n
+
+	    Method [GET/POST/PUT/DELETE/HEAD/TRACE/OPTIONS/CONNECT]
+		Blank
+		Request-URI [eg. /xxx/yyy?parm0=aaa&param1=bbb]
+		Blank
+		HTTP-Version [HTTP/1.0 | HTTP/1.2]
+		\r\n
+
 Request header
 Request body
 */
@@ -54,7 +56,6 @@ func parseHttpRequest(urlClusteringMethod urlclustering.ClusteringMethod) protoc
 
 		message.AddStringAttribute(constlabels.HttpMethod, string(method))
 		message.AddByteArrayUtf8Attribute(constlabels.HttpUrl, url)
-		message.AddByteArrayUtf8Attribute(constlabels.RequestPayload, message.GetData(0, protocol.GetHttpPayLoadLength()))
 
 		contentKey := urlClusteringMethod.Clustering(string(url))
 		if len(contentKey) == 0 {

--- a/collector/pkg/component/analyzer/network/protocol/http/http_response.go
+++ b/collector/pkg/component/analyzer/network/protocol/http/http_response.go
@@ -9,14 +9,17 @@ import (
 	"github.com/Kindling-project/kindling/collector/pkg/model/constlabels"
 )
 
-/**
+/*
+*
 Status line
+
 	HTTP-Version[HTTP/1.0 | HTTP/1.1]
 	Blank
 	Status-Code
 	Blank
 	Reason-Phrase
 	\r\n
+
 Response header
 Response body
 */
@@ -57,7 +60,6 @@ func parseHttpResponse() protocol.ParsePkgFn {
 		}
 
 		message.AddIntAttribute(constlabels.HttpStatusCode, statusCodeI)
-		message.AddByteArrayUtf8Attribute(constlabels.ResponsePayload, message.GetData(0, protocol.GetHttpPayLoadLength()))
 		if statusCodeI >= 400 {
 			message.AddBoolAttribute(constlabels.IsError, true)
 			message.AddIntAttribute(constlabels.ErrorType, int64(constlabels.ProtocolError))

--- a/collector/pkg/component/analyzer/network/protocol/protocol.go
+++ b/collector/pkg/component/analyzer/network/protocol/protocol.go
@@ -14,7 +14,11 @@ const (
 var payloadLength map[string]int = map[string]int{}
 
 func SetPayLoadLength(protocol string, length int) {
-	payloadLength[protocol] = length
+	if length > 0 {
+		payloadLength[protocol] = length
+	} else {
+		payloadLength[protocol] = 200
+	}
 }
 
 func GetPayLoadLength(protocol string) int {
@@ -22,12 +26,4 @@ func GetPayLoadLength(protocol string) int {
 		return length
 	}
 	return 200
-}
-
-func GetHttpPayLoadLength() int {
-	return GetPayLoadLength(HTTP)
-}
-
-func GetDubboPayLoadLength() int {
-	return GetPayLoadLength(DUBBO)
 }

--- a/collector/pkg/component/analyzer/network/protocol/protocol_parser.go
+++ b/collector/pkg/component/analyzer/network/protocol/protocol_parser.go
@@ -495,3 +495,25 @@ func (parser *ProtocolParser) ResetPort(port uint32) {
 	key := strconv.Itoa(int(port))
 	parser.portCounter.Remove(key)
 }
+
+func GetPayloadString(data []byte, protocolName string) string {
+	switch protocolName {
+	case HTTP, REDIS:
+		return tools.FormatByteArrayToUtf8(getSubstrBytes(data, protocolName, 0))
+	case DUBBO:
+		return tools.GetAsciiString(getSubstrBytes(data, protocolName, 16))
+	default:
+		return tools.GetAsciiString(getSubstrBytes(data, protocolName, 0))
+	}
+}
+
+func getSubstrBytes(data []byte, protocolName string, offset int) []byte {
+	length := GetPayLoadLength(protocolName)
+	if offset >= length {
+		return data[0:0]
+	}
+	if offset+length > len(data) {
+		return data[offset:]
+	}
+	return data[offset : offset+length]
+}

--- a/collector/pkg/component/analyzer/network/protocol/redis/redis_request.go
+++ b/collector/pkg/component/analyzer/network/protocol/redis/redis_request.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer/network/protocol"
-	"github.com/Kindling-project/kindling/collector/pkg/model/constlabels"
 )
 
 /*
@@ -21,7 +20,6 @@ func fastfailRedisRequest() protocol.FastFailFn {
 
 func parseRedisRequest() protocol.ParsePkgFn {
 	return func(message *protocol.PayloadMessage) (bool, bool) {
-		message.AddByteArrayUtf8Attribute(constlabels.RequestPayload, message.GetData(0, protocol.GetPayLoadLength(protocol.REDIS)))
 		return true, false
 	}
 }

--- a/collector/pkg/component/analyzer/network/protocol/redis/redis_response.go
+++ b/collector/pkg/component/analyzer/network/protocol/redis/redis_response.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer/network/protocol"
-	"github.com/Kindling-project/kindling/collector/pkg/model/constlabels"
 )
 
 /*
@@ -25,7 +24,6 @@ func fastfailResponse() protocol.FastFailFn {
 
 func parseResponse() protocol.ParsePkgFn {
 	return func(message *protocol.PayloadMessage) (bool, bool) {
-		message.AddByteArrayUtf8Attribute(constlabels.ResponsePayload, message.GetData(0, protocol.GetPayLoadLength(protocol.REDIS)))
 		return true, false
 	}
 }

--- a/collector/pkg/component/analyzer/network/protocol/testdata/dns/server-trace-multi.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/dns/server-trace-multi.yml
@@ -86,6 +86,8 @@ trace:
         dns_ip: "121.227.7.33"
         is_error: false
         error_type: 0
+        request_payload: ".............ss0.baidu.com.......)........"
+        response_payload: ".............ss0.baidu.com..................sslbaidu.jomodns...+.......2..y..!.."
     -
       Timestamp: 100396000
       Values:
@@ -114,3 +116,5 @@ trace:
         dns_rcode: 0
         is_error: false
         error_type: 0
+        request_payload: "9............ss0.baidu.com.......)........"
+        response_payload: "9............ss0.baidu.com..................sslbaidu.jomodns....)........"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/kafka/consumer-trace-fetch-multi-topics.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/kafka/consumer-trace-fetch-multi-topics.yml
@@ -57,3 +57,5 @@ trace:
         kafka_error_code: 0
         is_error: false
         error_type: 0
+        request_payload: "...\"..........consumer-merge-2............. .....(...=^......npm_request_trace.................tS...........................A...............npm_detail_topology_request...................:............."
+        response_payload: "................(....."

--- a/collector/pkg/component/analyzer/network/protocol/testdata/kafka/consumer-trace-fetch-split.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/kafka/consumer-trace-fetch-split.yml
@@ -64,3 +64,5 @@ trace:
         kafka_error_code: 0
         is_error: false
         error_type: 0
+        request_payload: "...g..........rdkafka...............................container-monitor..........."
+        response_payload: "...S....................container-monitor......................................."

--- a/collector/pkg/component/analyzer/network/protocol/testdata/kafka/provider-trace-produce-split.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/kafka/provider-trace-produce-split.yml
@@ -63,3 +63,5 @@ trace:
         kafka_error_code: 0
         is_error: false
         error_type: 0
+        request_payload: "...........@..rdkafka......u0......container-monitor...........O...........C...."
+        response_payload: "...A...@......container-monitor.................u...................."

--- a/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-query-split.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-query-split.yml
@@ -63,5 +63,7 @@ trace:
         protocol: "mysql"
         content_key: "select dummy *"
         sql: "SELECT * FROM dummy"
+        request_payload: ".....SELECT * FROM dummy"
+        response_payload: ".....9....def.container-monitor.dummy.dummy.name.name.-...........;....def.conta"
         is_error: false
         error_type: 0

--- a/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-query.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-query.yml
@@ -56,5 +56,7 @@ trace:
         protocol: "mysql"
         content_key: "select dummy *"
         sql: "SELECT * FROM dummy"
+        request_payload: ".....SELECT * FROM dummy"
+        response_payload: ".....9....def.container-monitor.dummy.dummy.name.name.-...........;....def.conta"
         is_error: false
         error_type: 0

--- a/collector/pkg/component/analyzer/network/protocol/testdata/na-protocol-config.yaml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/na-protocol-config.yaml
@@ -8,20 +8,21 @@ analyzers:
     conntrack_rate_limit: 500
     proc_root: /proc
     protocol_parser: [ http, mysql, dns, redis, kafka, dubbo, rocketmq ]
+    url_clustering_method: alphabet
     protocol_config:
       - key: "http"
+        ports: [ 80 ]
         payload_length: 80
       - key: "dubbo"
         payload_length: 80
       - key: "mysql"
+        ports: [ 3306 ]
         slow_threshold: 100
       - key: "kafka"
+        ports: [ 9092 ]
         slow_threshold: 100
-      - key: "cassandra"
-        ports: [ 9042 ]
-        slow_threshold: 100
-      - key: "s3"
-        ports: [ 9190 ]
+      - key: "redis"
+        ports: [ 6379 ]
         slow_threshold: 100
       - key: "dns"
         ports: [ 53 ]

--- a/collector/pkg/component/analyzer/network/protocol/testdata/rocketmq/server-trace-error.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/rocketmq/server-trace-error.yml
@@ -51,3 +51,5 @@ trace:
         rocketmq_error_msg: "TOPIC_NOT_EXIST"
         rocketmq_error_code: 17
         error_type: 3
+        request_payload: '........{"code":105,"extFields":{"topic":"TopicTest"},"flag":0,"language":"JAVA","opaque":2,"serializeTypeCurrentRPC":"JSON","version":401}'
+        response_payload: '........{"code":17,"flag":1,"language":"JAVA","opaque":2,"remark":"No topic route info in name server for the topic: TopicTest\nSee http://rocketmq.apache.org/docs/faq/ for further details.","serializ'

--- a/collector/pkg/component/analyzer/network/protocol/testdata/rocketmq/server-trace-json.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/rocketmq/server-trace-json.yml
@@ -81,3 +81,5 @@ trace:
         rocketmq_opaque: 1062
         rocketmq_error_code: 0
         error_type: 0
+        request_payload: '...h...d{"code":106,"flag":0,"language":"JAVA","opaque":1062,"serializeTypeCurrentRPC":"JSON","version":393}'
+        response_payload: '...H...b{"code":0,"flag":1,"language":"JAVA","opaque":1062,"serializeTypeCurrentRPC":"JSON","version":401}{"brokerAddrTable":{"rocketmq-5668b48cd9-h6gbz":{"brokerAddrs":{0:"10.233.90.93:10911"},"broke'

--- a/collector/pkg/component/analyzer/network/protocol/testdata/rocketmq/server-trace-rocketmq.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/rocketmq/server-trace-rocketmq.yml
@@ -91,3 +91,5 @@ trace:
         rocketmq_opaque: 2
         rocketmq_error_code: 0
         error_type: 0
+        request_payload: '...-...).i.....................topic....TopicTest'
+        response_payload: '...".........................{"brokerDatas":[{"brokerAddrs":{"0":"192.168.64.1:10911"},"brokerName":"broker-a","cluster":"DefaultCluster","enableActingMaster":false}],"filterServerTable":{},"queueData'

--- a/collector/pkg/component/analyzer/tools/ascii.go
+++ b/collector/pkg/component/analyzer/tools/ascii.go
@@ -1,0 +1,27 @@
+package tools
+
+const (
+	AsciiLow     = byte(0x20)
+	AsciiHigh    = byte(0x7e)
+	AsciiReplace = byte(0x2e) // .
+)
+
+/*
+ * Get the ascii readable string, replace other value to '.', like wireshark.
+ */
+func GetAsciiString(data []byte) string {
+	length := len(data)
+	if length == 0 {
+		return ""
+	}
+
+	newData := make([]byte, length)
+	for i := 0; i < length; i++ {
+		if data[i] > AsciiHigh || data[i] < AsciiLow {
+			newData[i] = AsciiReplace
+		} else {
+			newData[i] = data[i]
+		}
+	}
+	return string(newData)
+}

--- a/collector/pkg/component/consumer/exporter/tools/adapter/net_dict.go
+++ b/collector/pkg/component/consumer/exporter/tools/adapter/net_dict.go
@@ -269,6 +269,10 @@ var spanProtocol = []extraLabelsParam{
 		{constlabels.SpanResponsePayload, constlabels.ResponsePayload, String},
 	}, extraLabelsKey{ROCKETMQ}},
 	{[]dictionary{
+		/*
+		 * Currently we add payload span for all protocols everywhere as http\dubbo\redis has it's own key.
+		 * TODO Use unified way to set request/response payload.
+		 */
 		{constlabels.SpanRequestPayload, constlabels.RequestPayload, String},
 		{constlabels.SpanResponsePayload, constlabels.ResponsePayload, String},
 	}, extraLabelsKey{UNSUPPORTED},

--- a/collector/pkg/component/consumer/exporter/tools/adapter/net_dict.go
+++ b/collector/pkg/component/consumer/exporter/tools/adapter/net_dict.go
@@ -235,13 +235,21 @@ var spanProtocol = []extraLabelsParam{
 		{constlabels.SpanHttpResponseBody, constlabels.STR_EMPTY, StrEmpty},
 	}, extraLabelsKey{HTTP}},
 	{[]dictionary{
+		{constlabels.SpanRequestPayload, constlabels.RequestPayload, String},
+		{constlabels.SpanResponsePayload, constlabels.ResponsePayload, String},
+	}, extraLabelsKey{KAFKA}},
+	{[]dictionary{
 		{constlabels.SpanMysqlSql, constlabels.Sql, String},
 		{constlabels.SpanMysqlErrorCode, constlabels.SqlErrCode, Int64},
 		{constlabels.SpanMysqlErrorMsg, constlabels.SqlErrMsg, String},
+		{constlabels.SpanRequestPayload, constlabels.RequestPayload, String},
+		{constlabels.SpanResponsePayload, constlabels.ResponsePayload, String},
 	}, extraLabelsKey{MYSQL}},
 	{[]dictionary{
 		{constlabels.SpanDnsDomain, constlabels.DnsDomain, String},
 		{constlabels.SpanDnsRCode, constlabels.DnsRcode, FromInt64ToString},
+		{constlabels.SpanRequestPayload, constlabels.RequestPayload, String},
+		{constlabels.SpanResponsePayload, constlabels.ResponsePayload, String},
 	}, extraLabelsKey{DNS}},
 	{[]dictionary{
 		{constlabels.SpanDubboRequestBody, constlabels.RequestPayload, String},
@@ -257,9 +265,13 @@ var spanProtocol = []extraLabelsParam{
 	{[]dictionary{
 		{constlabels.SpanRocketMQRequestMsg, constlabels.RocketMQRequestMsg, String},
 		{constlabels.SpanRocketMQErrMsg, constlabels.RocketMQErrMsg, String},
+		{constlabels.SpanRequestPayload, constlabels.RequestPayload, String},
+		{constlabels.SpanResponsePayload, constlabels.ResponsePayload, String},
 	}, extraLabelsKey{ROCKETMQ}},
-	{
-		[]dictionary{}, extraLabelsKey{UNSUPPORTED},
+	{[]dictionary{
+		{constlabels.SpanRequestPayload, constlabels.RequestPayload, String},
+		{constlabels.SpanResponsePayload, constlabels.ResponsePayload, String},
+	}, extraLabelsKey{UNSUPPORTED},
 	},
 }
 

--- a/collector/pkg/model/constlabels/const.go
+++ b/collector/pkg/model/constlabels/const.go
@@ -112,6 +112,9 @@ const (
 	SpanRocketMQRequestMsg = "rocketmq.request_msg"
 	SpanRocketMQErrMsg     = "rocketmq.error_msg"
 
+	SpanRequestPayload  = "request_payload"
+	SpanResponsePayload = "response_payload"
+
 	NetWorkAnalyzeMetricGroup = "netAnalyzeMetrics"
 
 	// IsSent is used by cpuAnalyzer to label whether an event has been sent.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
   Some parsed protocols has request/response payloads, such as http/redis/dubbo. But when a protocol is discerned failed for some case, we need to know what payload it is so as to make it understandable.
## Description
<!--- Describe your changes in detail -->
  Payloads of any protocols will be added uniformly and make it readable in 3 ways in [protocol_parser.go](https://github.com/KindlingProject/kindling/compare/main...hocktea214:kindling:na-protocol-payload#diff-c3737abfba7f30c0cd2f9e362969d2effea204cabd10c492e98ca3b15e3f1472)
- HTTP and Redis use origin payload
- Dubbo use ascii payload without head
- Other protocols use ascii payload

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run TestCase in networkanalyzer_test.go
ok  	github.com/Kindling-project/kindling/collector/pkg/component/analyzer/network
