### PR TITLE
Add no_response_threshold(120s) for No response requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@
 
 
 ### Enhancements
-- Add payload for all protocols.([#375](https://github.com/KindlingProject/kindling/pull/375))
-- 
-- Add a new clustering method "blank" that is used to reduce the cardinality of metrics as much as possible. ([#372](https://github.com/KindlingProject/kindling/pull/372))
 - Add no_response_threshold(120s) for No response requests. ([#376](https://github.com/KindlingProject/kindling/pull/376))
+- Add payload for all protocols.([#375](https://github.com/KindlingProject/kindling/pull/375))
+- Add a new clustering method "blank" that is used to reduce the cardinality of metrics as much as possible. ([#372](https://github.com/KindlingProject/kindling/pull/372))
+
 
 ### Bug fixes
 - 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add payload for all protocols.([#375](https://github.com/KindlingProject/kindling/pull/375))
 - 
 - Add a new clustering method "blank" that is used to reduce the cardinality of metrics as much as possible. ([#372](https://github.com/KindlingProject/kindling/pull/372))
+- Add no_response_threshold(120s) for No response requests. ([#376](https://github.com/KindlingProject/kindling/pull/376))
 
 ### Bug fixes
 - 

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -42,8 +42,10 @@ analyzers:
   tcpmetricanalyzer:
   networkanalyzer:
     connect_timeout: 100
+    # How many seconds to wait until we consider a request as complete.
+    request_timeout: 15
     # How many seconds to wait until we consider a request as no response.
-    request_timeout: 60
+    no_response_threshold: 120
     # How many milliseconds to wait until we consider a request-response as slow.
     response_slow_threshold: 500
     # Whether enable conntrack module to find pod's ip when calling service
@@ -62,8 +64,6 @@ analyzers:
     #             containing non-alphabetical characters to star(*)
     # - blank: Turn endpoints to empty. This is used to reduce the cardinality as much as possible.
     url_clustering_method: alphabet
-    # If a request has not received a response after N seconds, the request will be sent as a NO_RESPONSE rquest.
-    no_response_threshold: 30
     # If the destination port of data is one of the followings, the protocol of such network request
     # is set to the corresponding one. Note the program will try to identify the protocol automatically
     # for the ports that are not in the lists, in which case the cpu usage will be increased much inevitably.

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -43,7 +43,7 @@ analyzers:
   networkanalyzer:
     connect_timeout: 100
     # How many seconds to wait until we consider a request as complete.
-    request_timeout: 15
+    fd_reuse_timeout: 15
     # How many seconds to wait until we consider a request as no response.
     no_response_threshold: 120
     # How many milliseconds to wait until we consider a request-response as slow.

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -62,6 +62,8 @@ analyzers:
     #             containing non-alphabetical characters to star(*)
     # - blank: Turn endpoints to empty. This is used to reduce the cardinality as much as possible.
     url_clustering_method: alphabet
+    # If a request has not received a response after N seconds, the request will be sent as a NO_RESPONSE rquest.
+    no_response_threshold: 30
     # If the destination port of data is one of the followings, the protocol of such network request
     # is set to the corresponding one. Note the program will try to identify the protocol automatically
     # for the ports that are not in the lists, in which case the cpu usage will be increased much inevitably.

--- a/collector/internal/application/testdata/kindling-collector-config.yaml
+++ b/collector/internal/application/testdata/kindling-collector-config.yaml
@@ -29,7 +29,7 @@ analyzers:
     num: 10
   networkanalyzer:
     connect_timeout: 100
-    request_timeout: 1
+    fd_reuse_timeout: 15
     response_slow_threshold: 500
     enable_conntrack: true
     conntrack_max_state_size: 131072

--- a/collector/pkg/component/analyzer/network/config.go
+++ b/collector/pkg/component/analyzer/network/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	ProtocolParser      []string         `mapstructure:"protocol_parser"`
 	ProtocolConfigs     []ProtocolConfig `mapstructure:"protocol_config,omitempty"`
 	UrlClusteringMethod string           `mapstructure:"url_clustering_method"`
+	NoResponseThreshold int              `mapstructure:"no_response_threshold"`
 }
 
 func NewDefaultConfig() *Config {
@@ -68,6 +69,7 @@ func NewDefaultConfig() *Config {
 			},
 		},
 		UrlClusteringMethod: "alphabet",
+		NoResponseThreshold: 30,
 	}
 }
 

--- a/collector/pkg/component/analyzer/network/config.go
+++ b/collector/pkg/component/analyzer/network/config.go
@@ -1,15 +1,16 @@
 package network
 
 const (
-	defaultRequestTimeout        = 15
+	defaultFdReuseTimeout        = 15
 	defaultNoResponseThreshold   = 120
 	defaultConnectTimeout        = 1
 	defaultResponseSlowThreshold = 500
 )
 
 type Config struct {
-	ConnectTimeout int `mapstructure:"connect_timeout"`
-	RequestTimeout int `mapstructure:"request_timeout"`
+	ConnectTimeout      int `mapstructure:"connect_timeout"`
+	FdReuseTimeout      int `mapstructure:"fd_reuse_timeout"`
+	NoResponseThreshold int `mapstructure:"no_response_threshold"`
 	// unit is ms
 	ResponseSlowThreshold int `mapstructure:"response_slow_threshold"`
 
@@ -21,13 +22,13 @@ type Config struct {
 	ProtocolParser      []string         `mapstructure:"protocol_parser"`
 	ProtocolConfigs     []ProtocolConfig `mapstructure:"protocol_config,omitempty"`
 	UrlClusteringMethod string           `mapstructure:"url_clustering_method"`
-	NoResponseThreshold int              `mapstructure:"no_response_threshold"`
 }
 
 func NewDefaultConfig() *Config {
 	return &Config{
 		ConnectTimeout:        100,
-		RequestTimeout:        60,
+		FdReuseTimeout:        15,
+		NoResponseThreshold:   120,
 		ResponseSlowThreshold: 500,
 		EnableConntrack:       true,
 		ConntrackMaxStateSize: 131072,
@@ -70,7 +71,6 @@ func NewDefaultConfig() *Config {
 			},
 		},
 		UrlClusteringMethod: "alphabet",
-		NoResponseThreshold: 120,
 	}
 }
 
@@ -90,11 +90,11 @@ func (cfg *Config) GetConnectTimeout() int {
 	}
 }
 
-func (cfg *Config) GetRequestTimeout() int {
-	if cfg.RequestTimeout > 0 {
-		return cfg.RequestTimeout
+func (cfg *Config) GetFdReuseTimeout() int {
+	if cfg.FdReuseTimeout > 0 {
+		return cfg.FdReuseTimeout
 	} else {
-		return defaultRequestTimeout
+		return defaultFdReuseTimeout
 	}
 }
 

--- a/collector/pkg/component/analyzer/network/config.go
+++ b/collector/pkg/component/analyzer/network/config.go
@@ -1,7 +1,8 @@
 package network
 
 const (
-	defaultRequestTimeout        = 1
+	defaultRequestTimeout        = 15
+	defaultNoResponseThreshold   = 120
 	defaultConnectTimeout        = 1
 	defaultResponseSlowThreshold = 500
 )
@@ -69,7 +70,7 @@ func NewDefaultConfig() *Config {
 			},
 		},
 		UrlClusteringMethod: "alphabet",
-		NoResponseThreshold: 30,
+		NoResponseThreshold: 120,
 	}
 }
 
@@ -102,5 +103,13 @@ func (cfg *Config) getResponseSlowThreshold() int {
 		return cfg.ResponseSlowThreshold
 	} else {
 		return defaultResponseSlowThreshold
+	}
+}
+
+func (cfg *Config) getNoResponseThreshold() int {
+	if cfg.NoResponseThreshold > 0 {
+		return cfg.NoResponseThreshold
+	} else {
+		return defaultNoResponseThreshold
 	}
 }

--- a/collector/pkg/component/analyzer/network/message_pair.go
+++ b/collector/pkg/component/analyzer/network/message_pair.go
@@ -114,6 +114,10 @@ func (evts *events) IsTimeout(newEvt *model.KindlingEvent, timeout int) bool {
 	return false
 }
 
+func (evts *events) IsSportChanged(newEvt *model.KindlingEvent) bool {
+	return newEvt.GetSport() != evts.event.GetSport()
+}
+
 func (evts *events) getDuration() uint64 {
 	if evts == nil {
 		return 0
@@ -132,7 +136,7 @@ type messagePairs struct {
 	responses *events
 	natTuple  *conntracker.IPTranslation
 	isSend    bool
-	mutex sync.RWMutex // only for update latency and resval now
+	mutex     sync.RWMutex // only for update latency and resval now
 }
 
 func (mps *messagePairs) getKey() messagePairKey {

--- a/collector/pkg/component/analyzer/network/message_pair.go
+++ b/collector/pkg/component/analyzer/network/message_pair.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Kindling-project/kindling/collector/pkg/metadata/conntracker"
@@ -135,8 +136,13 @@ type messagePairs struct {
 	requests  *events
 	responses *events
 	natTuple  *conntracker.IPTranslation
-	isSend    bool
+	isSend    int32
 	mutex     sync.RWMutex // only for update latency and resval now
+}
+
+func (mps *messagePairs) checkSend() bool {
+	// Check Send Once.
+	return atomic.AddInt32(&mps.isSend, 1) == 1
 }
 
 func (mps *messagePairs) getKey() messagePairKey {

--- a/collector/pkg/component/analyzer/network/network_analyzer.go
+++ b/collector/pkg/component/analyzer/network/network_analyzer.go
@@ -193,7 +193,7 @@ func (na *NetworkAnalyzer) consumerFdNoReusingTrace() {
 			na.requestMonitor.Range(func(k, v interface{}) bool {
 				mps := v.(*messagePairs)
 				var timeoutTs = mps.getTimeoutTs()
-				if timeoutTs != 0 && (time.Now().UnixNano()/1000000000-int64(timeoutTs)/1000000000) >= 15 {
+				if timeoutTs != 0 && (time.Now().UnixNano()/1000000000-int64(timeoutTs)/1000000000) >= int64(na.cfg.NoResponseThreshold) {
 					na.distributeTraceMetric(mps, nil)
 				}
 				return true

--- a/collector/pkg/component/analyzer/network/network_analyzer.go
+++ b/collector/pkg/component/analyzer/network/network_analyzer.go
@@ -303,6 +303,11 @@ func (na *NetworkAnalyzer) distributeTraceMetric(oldPairs *messagePairs, newPair
 		return nil
 	}
 
+	if oldPairs.checkSend() == false {
+		// FIX send twice for request/response with 15s delay.
+		return nil
+	}
+
 	if newPairs != nil {
 		na.requestMonitor.Store(newPairs.getKey(), newPairs)
 	} else {

--- a/collector/pkg/component/analyzer/network/network_analyzer.go
+++ b/collector/pkg/component/analyzer/network/network_analyzer.go
@@ -196,10 +196,10 @@ func (na *NetworkAnalyzer) consumerFdNoReusingTrace() {
 				if timeoutTs != 0 {
 					var duration = (time.Now().UnixNano()/1000000000 - int64(timeoutTs)/1000000000)
 					if mps.responses != nil && duration >= int64(na.cfg.GetFdReuseTimeout()) {
-						// No New Request
+						// No FdReuse Request
 						na.distributeTraceMetric(mps, nil)
 					} else if duration >= int64(na.cfg.getNoResponseThreshold()) {
-						// Request 498
+						// No Response Request
 						na.distributeTraceMetric(mps, nil)
 					}
 				}

--- a/collector/pkg/component/analyzer/network/network_analyzer.go
+++ b/collector/pkg/component/analyzer/network/network_analyzer.go
@@ -195,7 +195,7 @@ func (na *NetworkAnalyzer) consumerFdNoReusingTrace() {
 				var timeoutTs = mps.getTimeoutTs()
 				if timeoutTs != 0 {
 					var duration = (time.Now().UnixNano()/1000000000 - int64(timeoutTs)/1000000000)
-					if mps.responses != nil && duration >= int64(na.cfg.GetRequestTimeout()) {
+					if mps.responses != nil && duration >= int64(na.cfg.GetFdReuseTimeout()) {
 						// No New Request
 						na.distributeTraceMetric(mps, nil)
 					} else if duration >= int64(na.cfg.getNoResponseThreshold()) {

--- a/collector/pkg/component/analyzer/network/protocol/testdata/na-protocol-config.yaml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/na-protocol-config.yaml
@@ -1,7 +1,7 @@
 analyzers:
   networkanalyzer:
     connect_timeout: 100
-    request_timeout: 1
+    fd_reuse_timeout: 15
     response_slow_threshold: 500
     enable_conntrack: false
     conntrack_max_state_size: 131072

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -42,8 +42,10 @@ analyzers:
   tcpmetricanalyzer:
   networkanalyzer:
     connect_timeout: 100
+    # How many seconds to wait until we consider a request as complete.
+    request_timeout: 15
     # How many seconds to wait until we consider a request as no response.
-    request_timeout: 60
+    no_response_threshold: 120
     # How many milliseconds to wait until we consider a request-response as slow.
     response_slow_threshold: 500
     # Whether enable conntrack module to find pod's ip when calling service
@@ -62,8 +64,6 @@ analyzers:
     #             containing non-alphabetical characters to star(*)
     # - blank: Turn endpoints to empty. This is used to reduce the cardinality as much as possible.
     url_clustering_method: alphabet
-    # If a request has not received a response after N seconds, the request will be sent as a NO_RESPONSE rquest.
-    no_response_threshold: 30
     # If the destination port of data is one of the followings, the protocol of such network request
     # is set to the corresponding one. Note the program will try to identify the protocol automatically
     # for the ports that are not in the lists, in which case the cpu usage will be increased much inevitably.

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -43,7 +43,7 @@ analyzers:
   networkanalyzer:
     connect_timeout: 100
     # How many seconds to wait until we consider a request as complete.
-    request_timeout: 15
+    fd_reuse_timeout: 15
     # How many seconds to wait until we consider a request as no response.
     no_response_threshold: 120
     # How many milliseconds to wait until we consider a request-response as slow.

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -62,6 +62,8 @@ analyzers:
     #             containing non-alphabetical characters to star(*)
     # - blank: Turn endpoints to empty. This is used to reduce the cardinality as much as possible.
     url_clustering_method: alphabet
+    # If a request has not received a response after N seconds, the request will be sent as a NO_RESPONSE rquest.
+    no_response_threshold: 30
     # If the destination port of data is one of the followings, the protocol of such network request
     # is set to the corresponding one. Note the program will try to identify the protocol automatically
     # for the ports that are not in the lists, in which case the cpu usage will be increased much inevitably.


### PR DESCRIPTION
Signed-off-by: huxiangyuan <huxiangyuan@harmonycloud.cn>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There're two checks for no response request and completed request with same 15s check.
In fact, complete request should check timely with 15s
But the no response request should wait long period with 120s which is set with no_response_threshold in config file.

Besides, there may be multi-send with same request, use atomic  check for send once.
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->