### PR TITLE
Add NAT labels even if the response is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Bug fixes
 - Fix the bug where the pod metadata with persistent IP in the map is deleted incorrectly due to the deleting mechanism with a delay. ([#374](https://github.com/KindlingProject/kindling/pull/374))
+- Fix the bug that when the response is nil, the NAT IP and port are not added to the labels of the "DataGroup". ([#378](https://github.com/KindlingProject/kindling/pull/378))
 - Fix potential deadlock of exited thread delay queue. ([#373](https://github.com/KindlingProject/kindling/pull/373))
 - Fix the bug that cpuEvent cache size continuously increases even if trace profiling is not enabled.([#362](https://github.com/KindlingProject/kindling/pull/362))
 - Fix the bug that duplicate CPU events are indexed into Elasticsearch. ([#359](https://github.com/KindlingProject/kindling/pull/359))

--- a/collector/pkg/component/analyzer/network/network_analyzer.go
+++ b/collector/pkg/component/analyzer/network/network_analyzer.go
@@ -8,14 +8,15 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/Kindling-project/kindling/collector/pkg/component"
 	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer"
 	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer/network/protocol"
 	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer/network/protocol/factory"
 	"github.com/Kindling-project/kindling/collector/pkg/component/consumer"
-	conntracker2 "github.com/Kindling-project/kindling/collector/pkg/metadata/conntracker"
+	"github.com/Kindling-project/kindling/collector/pkg/metadata/conntracker"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constnames"
-	"go.opentelemetry.io/otel/attribute"
 
 	"go.uber.org/zap/zapcore"
 
@@ -34,7 +35,7 @@ const (
 type NetworkAnalyzer struct {
 	cfg           *Config
 	nextConsumers []consumer.Consumer
-	conntracker   conntracker2.Conntracker
+	conntracker   conntracker.Conntracker
 
 	staticPortMap    map[uint32]string
 	slowThresholdMap map[string]int
@@ -58,7 +59,7 @@ func NewNetworkAnalyzer(cfg interface{}, telemetry *component.TelemetryTools, co
 		telemetry:     telemetry,
 	}
 	if config.EnableConntrack {
-		connConfig := &conntracker2.Config{
+		connConfig := &conntracker.Config{
 			Enabled:                      config.EnableConntrack,
 			ProcRoot:                     config.ProcRoot,
 			ConntrackInitTimeout:         30 * time.Second,
@@ -66,7 +67,7 @@ func NewNetworkAnalyzer(cfg interface{}, telemetry *component.TelemetryTools, co
 			ConntrackMaxStateSize:        config.ConntrackMaxStateSize,
 			EnableConntrackAllNamespaces: true,
 		}
-		na.conntracker, _ = conntracker2.NewConntracker(connConfig)
+		na.conntracker, _ = conntracker.NewConntracker(connConfig)
 	}
 
 	na.parserFactory = factory.NewParserFactory(factory.WithUrlClusteringMethod(na.cfg.UrlClusteringMethod))
@@ -559,7 +560,7 @@ func (na *NetworkAnalyzer) getRecords(mps *messagePairs, protocol string, attrib
 		labels.AddIntValue(constlabels.ErrorType, int64(constlabels.NoResponse))
 	}
 
-	if nil != mps.natTuple && mps.responses != nil {
+	if nil != mps.natTuple {
 		labels.UpdateAddStringValue(constlabels.DnatIp, mps.natTuple.ReplSrcIP.String())
 		labels.UpdateAddIntValue(constlabels.DnatPort, int64(mps.natTuple.ReplSrcPort))
 	}
@@ -614,7 +615,7 @@ func (na *NetworkAnalyzer) getRecordWithSinglePair(mps *messagePairs, mp *messag
 		labels.AddIntValue(constlabels.ErrorType, int64(constlabels.NoResponse))
 	}
 
-	if nil != mps.natTuple && mps.responses != nil {
+	if nil != mps.natTuple {
 		labels.UpdateAddStringValue(constlabels.DnatIp, mps.natTuple.ReplSrcIP.String())
 		labels.UpdateAddIntValue(constlabels.DnatPort, int64(mps.natTuple.ReplSrcPort))
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add NAT labels even if the response is nil. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR aims to fix the bug that when the response is nil, the NAT IP and port are not added to the labels of the "DataGroup".
