### PR TITLE
Add request_tid and response_tid for trace labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 
 ### Enhancements
+- Add request_tid and response_tid for trace labels.([#379](https://github.com/KindlingProject/kindling/pull/379))
 - Add no_response_threshold(120s) for No response requests. ([#376](https://github.com/KindlingProject/kindling/pull/376))
 - Add payload for all protocols.([#375](https://github.com/KindlingProject/kindling/pull/375))
 - Add a new clustering method "blank" that is used to reduce the cardinality of metrics as much as possible. ([#372](https://github.com/KindlingProject/kindling/pull/372))

--- a/collector/pkg/component/analyzer/network/protocol/testdata/dns/server-trace-multi.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/dns/server-trace-multi.yml
@@ -70,6 +70,8 @@ trace:
       Labels:
         comm: "systemd-resolve"
         pid: 577
+        request_tid: 577
+        response_tid: 577
         src_ip: "127.0.0.1"
         src_port: 60129
         dst_ip: "127.0.0.53"
@@ -101,6 +103,8 @@ trace:
       Labels:
         comm: "systemd-resolve"
         pid: 577
+        request_tid: 577
+        response_tid: 577
         src_ip: "127.0.0.1"
         src_port: 60129
         dst_ip: "127.0.0.53"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/dubbo/server-trace-short.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/dubbo/server-trace-short.yml
@@ -38,6 +38,8 @@ trace:
       Labels:
         comm: "java"
         pid: 942
+        request_tid: 954
+        response_tid: 954
         src_ip: "127.0.0.1"
         src_port: 41458
         dst_ip: "127.0.0.1"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/http/server-trace-error.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/http/server-trace-error.yml
@@ -38,6 +38,8 @@ trace:
       Labels:
         comm: testdemo
         pid: 12345
+        request_tid: 12346
+        response_tid: 12346
         src_ip: "127.0.0.1"
         src_port: 56266
         dst_ip: "127.0.0.1"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/http/server-trace-normal.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/http/server-trace-normal.yml
@@ -38,6 +38,8 @@ trace:
       Labels:
         comm: testdemo
         pid: 12345
+        request_tid: 12346
+        response_tid: 12346
         src_ip: "127.0.0.1"
         src_port: 56266
         dst_ip: "127.0.0.1"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/http/server-trace-slow.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/http/server-trace-slow.yml
@@ -38,6 +38,8 @@ trace:
       Labels:
         comm: testdemo
         pid: 12345
+        request_tid: 12346
+        response_tid: 12346
         src_ip: "127.0.0.1"
         src_port: 56266
         dst_ip: "127.0.0.1"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/http/server-trace-split.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/http/server-trace-split.yml
@@ -38,6 +38,8 @@ trace:
       Labels:
         comm: testdemo
         pid: 12345
+        request_tid: 12346
+        response_tid: 12346
         src_ip: "127.0.0.1"
         src_port: 56266
         dst_ip: "127.0.0.1"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/kafka/consumer-trace-fetch-multi-topics.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/kafka/consumer-trace-fetch-multi-topics.yml
@@ -40,6 +40,8 @@ trace:
       Labels:
         comm: "rdk:broker1"
         pid: 925
+        request_tid: 937
+        response_tid: 937
         src_ip: "127.0.0.1"
         src_port: 38970
         dst_ip: "127.0.0.1"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/kafka/consumer-trace-fetch-split.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/kafka/consumer-trace-fetch-split.yml
@@ -47,6 +47,8 @@ trace:
       Labels:
         comm: "rdk:broker1"
         pid: 925
+        request_tid: 937
+        response_tid: 937
         src_ip: "127.0.0.1"
         src_port: 38970
         dst_ip: "127.0.0.1"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/kafka/provider-trace-produce-split.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/kafka/provider-trace-produce-split.yml
@@ -46,6 +46,8 @@ trace:
       Labels:
         comm: "rdk:broker1"
         pid: 942
+        request_tid: 954
+        response_tid: 954
         src_ip: "127.0.0.1"
         src_port: 38966
         dst_ip: "127.0.0.1"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-query-split.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-query-split.yml
@@ -51,6 +51,8 @@ trace:
       Labels:
         comm: "mysqld"
         pid: 903
+        request_tid: 2744
+        response_tid: 2744
         src_ip: "127.0.0.1"
         src_port: 49368
         dst_ip: "127.0.0.1"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-query.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-query.yml
@@ -44,6 +44,8 @@ trace:
       Labels:
         comm: "mysqld"
         pid: 903
+        request_tid: 2744
+        response_tid: 2744
         src_ip: "127.0.0.1"
         src_port: 49368
         dst_ip: "127.0.0.1"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/redis/server-trace-get.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/redis/server-trace-get.yml
@@ -32,6 +32,8 @@ trace:
       Labels:
         comm: "redis-server"
         pid: 817
+        request_tid: 817
+        response_tid: 817
         src_ip: "127.0.0.1"
         src_port: 39130
         dst_ip: "127.0.0.1"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/rocketmq/server-trace-error.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/rocketmq/server-trace-error.yml
@@ -34,6 +34,8 @@ trace:
       Labels:
         comm: "rocketmq-server"
         pid: 12346
+        request_tid: 12347
+        response_tid: 12347
         src_ip: "127.0.0.1"
         src_port: 45678
         dst_ip: "127.0.0.1"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/rocketmq/server-trace-json.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/rocketmq/server-trace-json.yml
@@ -65,6 +65,8 @@ trace:
       Labels:
         comm: "rocketmq-server"
         pid: 12346
+        request_tid: 12347
+        response_tid: 12347
         src_ip: "127.0.0.1"
         src_port: 45678
         dst_ip: "127.0.0.1"

--- a/collector/pkg/component/analyzer/network/protocol/testdata/rocketmq/server-trace-rocketmq.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/rocketmq/server-trace-rocketmq.yml
@@ -75,6 +75,8 @@ trace:
       Labels:
         comm: "rocketmq-server"
         pid: 12346
+        request_tid: 12347
+        response_tid: 12347
         src_ip: "127.0.0.1"
         src_port: 45678
         dst_ip: "127.0.0.1"

--- a/collector/pkg/component/consumer/exporter/tools/adapter/net_dict.go
+++ b/collector/pkg/component/consumer/exporter/tools/adapter/net_dict.go
@@ -105,6 +105,8 @@ var SpanDicList = []dictionary{
 	{constlabels.SrcNode, constlabels.SrcNode, String},
 	{constlabels.SrcPod, constlabels.SrcPod, String},
 	{constlabels.Pid, constlabels.Pid, Int64},
+	{constlabels.RequestTid, constlabels.RequestTid, Int64},
+	{constlabels.ResponseTid, constlabels.ResponseTid, Int64},
 	{constlabels.Comm, constlabels.Comm, String},
 }
 

--- a/collector/pkg/model/constlabels/const.go
+++ b/collector/pkg/model/constlabels/const.go
@@ -10,6 +10,8 @@ const (
 const (
 	Comm            = "comm"
 	Pid             = "pid"
+	RequestTid      = "request_tid"
+	ResponseTid     = "response_tid"
 	Tid             = "tid"
 	Protocol        = "protocol"
 	IsError         = "is_error"

--- a/collector/pkg/model/kindling_event_helper.go
+++ b/collector/pkg/model/kindling_event_helper.go
@@ -126,6 +126,18 @@ func (x *KindlingEvent) GetPid() uint32 {
 	return threadInfo.Pid
 }
 
+func (x *KindlingEvent) GetTid() uint32 {
+	ctx := x.GetCtx()
+	if ctx == nil {
+		return 0
+	}
+	threadInfo := ctx.GetThreadInfo()
+	if threadInfo == nil {
+		return 0
+	}
+	return threadInfo.Tid
+}
+
 func (x *KindlingEvent) GetComm() string {
 	ctx := x.GetCtx()
 	if ctx == nil {


### PR DESCRIPTION
Signed-off-by: huxiangyuan <huxiangyuan@harmonycloud.cn>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add request and response tid for trace data.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run TestCase in networkanalyzer_test.go
ok github.com/Kindling-project/kindling/collector/pkg/component/analyzer/network