### PR TITLE
Fix the wrong thread name in the trace profiling function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 
 ### Bug fixes
+- Fix the wrong thread name in the trace profiling function. ([#385])(https://github.com/KindlingProject/kindling/pull/385)
 - Remove "reset" method of ScheduledTaskRoutine to fix a potential dead-lock issue. ([#369])(https://github.com/KindlingProject/kindling/pull/369)
 - Fix the bug where the pod metadata with persistent IP in the map is deleted incorrectly due to the deleting mechanism with a delay. ([#374](https://github.com/KindlingProject/kindling/pull/374))
 - Fix the bug that when the response is nil, the NAT IP and port are not added to the labels of the "DataGroup". ([#378](https://github.com/KindlingProject/kindling/pull/378))

--- a/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
@@ -218,10 +218,11 @@ func (ca *CpuAnalyzer) PutEventToSegments(pid uint32, tid uint32, threadName str
 
 	} else {
 		newTimeSegments := &TimeSegments{
-			Pid:      pid,
-			Tid:      tid,
-			BaseTime: event.StartTimestamp() / nanoToSeconds,
-			Segments: NewCircleQueue(maxSegmentSize),
+			Pid:        pid,
+			Tid:        tid,
+			ThreadName: threadName,
+			BaseTime:   event.StartTimestamp() / nanoToSeconds,
+			Segments:   NewCircleQueue(maxSegmentSize),
 		}
 		for i := 0; i < maxSegmentSize; i++ {
 			segment := newSegment((newTimeSegments.BaseTime+uint64(i))*nanoToSeconds,

--- a/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
@@ -181,8 +181,7 @@ func (ca *CpuAnalyzer) PutEventToSegments(pid uint32, tid uint32, threadName str
 				endOffset = endOffset - startOffset
 				startOffset = 0
 				for i := 0; i < maxSegmentSize; i++ {
-					segment := newSegment(pid, tid, threadName,
-						(timeSegments.BaseTime+uint64(i))*nanoToSeconds,
+					segment := newSegment((timeSegments.BaseTime+uint64(i))*nanoToSeconds,
 						(timeSegments.BaseTime+uint64(i+1))*nanoToSeconds)
 					timeSegments.Segments.UpdateByIndex(i, segment)
 				}
@@ -201,14 +200,14 @@ func (ca *CpuAnalyzer) PutEventToSegments(pid uint32, tid uint32, threadName str
 					movedIndex := i + clearSize
 					val := timeSegments.Segments.GetByIndex(movedIndex)
 					timeSegments.Segments.UpdateByIndex(i, val)
-					segmentTmp := newSegment(pid, tid, threadName,
-						(timeSegments.BaseTime+uint64(movedIndex))*nanoToSeconds,
+					segmentTmp := newSegment((timeSegments.BaseTime+uint64(movedIndex))*nanoToSeconds,
 						(timeSegments.BaseTime+uint64(movedIndex+1))*nanoToSeconds)
 					timeSegments.Segments.UpdateByIndex(movedIndex, segmentTmp)
 				}
 			}
 		}
 
+		timeSegments.updateThreadName(threadName) //update the thread name immediatly
 		for i := startOffset; i <= endOffset && i < maxSegmentSize; i++ {
 			val := timeSegments.Segments.GetByIndex(i)
 			segment := val.(*Segment)
@@ -225,8 +224,7 @@ func (ca *CpuAnalyzer) PutEventToSegments(pid uint32, tid uint32, threadName str
 			Segments: NewCircleQueue(maxSegmentSize),
 		}
 		for i := 0; i < maxSegmentSize; i++ {
-			segment := newSegment(pid, tid, threadName,
-				(newTimeSegments.BaseTime+uint64(i))*nanoToSeconds,
+			segment := newSegment((newTimeSegments.BaseTime+uint64(i))*nanoToSeconds,
 				(newTimeSegments.BaseTime+uint64(i+1))*nanoToSeconds)
 			newTimeSegments.Segments.UpdateByIndex(i, segment)
 		}

--- a/collector/pkg/component/analyzer/cpuanalyzer/model.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/model.go
@@ -36,6 +36,10 @@ type TimeSegments struct {
 	Segments   *CircleQueue `json:"segments"`
 }
 
+func (t *TimeSegments) updateThreadName(threadName string) {
+	t.ThreadName = threadName
+}
+
 type Segment struct {
 	StartTime       uint64       `json:"startTime"`
 	EndTime         uint64       `json:"endTime"`
@@ -57,9 +61,7 @@ func newSegment(startTime uint64, endTime uint64) *Segment {
 		IndexTimestamp:  "",
 	}
 }
-func (t *TimeSegments) updateThreadName(threadName string) {
-	t.ThreadName = threadName
-}
+
 func (s *Segment) putTimedEvent(event TimedEvent) {
 	switch event.Kind() {
 	case TimedCpuEventKind:

--- a/collector/pkg/component/analyzer/cpuanalyzer/send_trigger.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/send_trigger.go
@@ -128,7 +128,7 @@ func (ca *CpuAnalyzer) sendEvents(keyElements *model.AttributeMap, pid uint32, s
 			if len(segment.CpuEvents) != 0 {
 				// Don't remove the duplicated one
 				segment.IndexTimestamp = time.Now().String()
-				dataGroup := segment.toDataGroup()
+				dataGroup := segment.toDataGroup(timeSegments)
 				dataGroup.Labels.Merge(keyElements)
 				for _, nexConsumer := range ca.nextConsumers {
 					_ = nexConsumer.Consume(dataGroup)

--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -430,8 +430,8 @@ void parse_jf(char* data_val, sinsp_evt_param data_param, kindling_event_t_for_g
       ptid_comm.find(threadInfo->m_pid << 32 | (threadInfo->m_tid & 0xFFFFFFFF));
   if (key != ptid_comm.end()) {
     strcpy(p_kindling_event->context.tinfo.comm, key->second);
-  }else{
-    strcpy(p_kindling_event->context.tinfo.comm,  (char*)threadInfo->m_comm.data());
+  } else {
+    strcpy(p_kindling_event->context.tinfo.comm, (char*)threadInfo->m_comm.data());
   }
   p_kindling_event->context.tinfo.pid = threadInfo->m_pid;
   p_kindling_event->paramsNumber = userAttNumber;
@@ -480,8 +480,8 @@ void parse_xtid(sinsp_evt* s_evt, char* data_val, sinsp_evt_param data_param,
       ptid_comm.find(threadInfo->m_pid << 32 | (threadInfo->m_tid & 0xFFFFFFFF));
   if (key != ptid_comm.end()) {
     strcpy(p_kindling_event->context.tinfo.comm, key->second);
-  }else{
-    strcpy(p_kindling_event->context.tinfo.comm,  (char*)threadInfo->m_comm.data());
+  } else {
+    strcpy(p_kindling_event->context.tinfo.comm, (char*)threadInfo->m_comm.data());
   }
   p_kindling_event->context.tinfo.pid = threadInfo->m_pid;
   p_kindling_event->paramsNumber = userAttNumber;

--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -430,6 +430,8 @@ void parse_jf(char* data_val, sinsp_evt_param data_param, kindling_event_t_for_g
       ptid_comm.find(threadInfo->m_pid << 32 | (threadInfo->m_tid & 0xFFFFFFFF));
   if (key != ptid_comm.end()) {
     strcpy(p_kindling_event->context.tinfo.comm, key->second);
+  }else{
+    strcpy(p_kindling_event->context.tinfo.comm,  (char*)threadInfo->m_comm.data());
   }
   p_kindling_event->context.tinfo.pid = threadInfo->m_pid;
   p_kindling_event->paramsNumber = userAttNumber;
@@ -478,6 +480,8 @@ void parse_xtid(sinsp_evt* s_evt, char* data_val, sinsp_evt_param data_param,
       ptid_comm.find(threadInfo->m_pid << 32 | (threadInfo->m_tid & 0xFFFFFFFF));
   if (key != ptid_comm.end()) {
     strcpy(p_kindling_event->context.tinfo.comm, key->second);
+  }else{
+    strcpy(p_kindling_event->context.tinfo.comm,  (char*)threadInfo->m_comm.data());
   }
   p_kindling_event->context.tinfo.pid = threadInfo->m_pid;
   p_kindling_event->paramsNumber = userAttNumber;


### PR DESCRIPTION
Signed-off-by: yaofighting <siyao@zju.edu.cn>

<!--- Provide a general summary of your changes in the Title above -->
Fix the thread name error in the trace profiling function, and optimize the segment field in the cycle_queue in collector. 
## Problem1. Thread name error
### Analysis-Probe
When the java probe thread itself generates its own java_futex information for the first time, it enters Probe-side ` parse_ jf() ` function, at this time ` parse_ tm() ` thread has not been processed yet, so the ` ptid_comm` map has no thread name information of this thread. However, in the code logic, it only writes the logic to assign the thread name when the thread exists in the `ptid_comm`map. When the map does not exist, it does nothing. (Therefore, the comm field in kindling_event is actually the comm of the previous data.) like this: 
`if (key != ptid_comm.end()) {
    strcpy(p_kindling_event->context.tinfo.comm, key->second);
  }`
### Analysis-Collector
At this time, the incorrect comm data will enter the `ConsumeEvent ->ConsumeJavaFutexEvent ->PutEventToSegments` logic in the Go side cpuanalyzer to establish the first entry information of the thread. At this time, a ring will be initialized and the thread name information will be initialized. Unless the ring is cleaned up later, the thread name information will not be updated in a timely manner, so it's also a problem in collector. 
### Solution
For theProbe-side, add the default comm data value, and for the Collector-side, ensure that the thread name information is updated every time the ring is updated. 

## Problem2. Data redundancy in Collector-Segment
optimize the segment field in the cycle_queue in collector.