### PR TITLE
add startup arg snaplen to control max length of syscall data buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 
 ## Unreleased
 ### New features
-- Support the protocol RocketMQ.([#328](https://github.com/KindlingProject/kindling/pull/328))
-- Add a new tool: A debug tool for Trace Profiling is provided for developers to troubleshoot problems.([#363](https://github.com/KindlingProject/kindling/pull/363))
-- Add tracing span data in cpu events. ([#384](https://github.com/KindlingProject/kindling/pull/384))
 - Support to configure `snaplen` through startup args.([#387](https://github.com/KindlingProject/kindling/pull/387))
+- Add tracing span data in cpu events. ([#384](https://github.com/KindlingProject/kindling/pull/384))
+- Add a new tool: A debug tool for Trace Profiling is provided for developers to troubleshoot problems.([#363](https://github.com/KindlingProject/kindling/pull/363))
+- Support the protocol RocketMQ.([#328](https://github.com/KindlingProject/kindling/pull/328))
 
 ### Enhancements
 - Add the field `end_timestamp` to the trace data to make it easier for querying. ([#380](https://github.com/KindlingProject/kindling/pull/380))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Support the protocol RocketMQ.([#328](https://github.com/KindlingProject/kindling/pull/328))
 - Add a new tool: A debug tool for Trace Profiling is provided for developers to troubleshoot problems.([#363](https://github.com/KindlingProject/kindling/pull/363))
 - Add tracing span data in cpu events. ([#384](https://github.com/KindlingProject/kindling/pull/384))
+- Support to configure `snaplen` through startup args.([#387](https://github.com/KindlingProject/kindling/pull/387))
 
 ### Enhancements
 - Add the field `end_timestamp` to the trace data to make it easier for querying. ([#380](https://github.com/KindlingProject/kindling/pull/380))

--- a/deploy/agent/kindling-deploy.yml
+++ b/deploy/agent/kindling-deploy.yml
@@ -53,6 +53,8 @@ spec:
           value: /host
         - name: SYSDIG_HOST_ROOT
           value: /host
+        - name: SNAPLEN
+          value: 1000
         - name: GOGC
           value: "400"
         - name: MY_NODE_IP

--- a/deploy/agent/kindling-deploy.yml
+++ b/deploy/agent/kindling-deploy.yml
@@ -54,7 +54,7 @@ spec:
         - name: SYSDIG_HOST_ROOT
           value: /host
         - name: SNAPLEN
-          value: 1000
+          value: "1000"
         - name: GOGC
           value: "400"
         - name: MY_NODE_IP

--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -115,10 +115,10 @@ void set_snaplen(sinsp* inspector) {
     snaplen = atol(env_snaplen);
     if (snaplen == 0 || snaplen > RW_MAX_SNAPLEN) {
       snaplen = RW_SNAPLEN;
-      cout << "Invalid snaplen value, reset to default " <<  RW_SNAPLEN << endl;
+      cout << "Invalid snaplen value, reset to default " << RW_SNAPLEN << endl;
     }
   }
-  
+
   cout << "Set snaplen to value: " << snaplen << endl;
   inspector->set_snaplen(snaplen);
 }

--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -107,15 +107,16 @@ void set_eventmask(sinsp* inspector) {
   }
 }
 
+#define DEFAULT_SNAPLEN 1000
 void set_snaplen(sinsp* inspector) {
-  uint32_t snaplen = 80;
+  uint32_t snaplen = DEFAULT_SNAPLEN;
 
   char* env_snaplen = getenv("SNAPLEN");
   if (env_snaplen != nullptr) {
     snaplen = atol(env_snaplen);
     if (snaplen == 0 || snaplen > RW_MAX_SNAPLEN) {
-      snaplen = RW_SNAPLEN;
-      cout << "Invalid snaplen value, reset to default " << RW_SNAPLEN << endl;
+      snaplen = DEFAULT_SNAPLEN;
+      cout << "Invalid snaplen value, reset to default " << DEFAULT_SNAPLEN << endl;
     }
   }
 

--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -107,16 +107,16 @@ void set_eventmask(sinsp* inspector) {
   }
 }
 
-#define DEFAULT_SNAPLEN 1000
+#define KINDLING_DEFAULT_SNAPLEN 1000
 void set_snaplen(sinsp* inspector) {
-  uint32_t snaplen = DEFAULT_SNAPLEN;
+  uint32_t snaplen = KINDLING_DEFAULT_SNAPLEN;
 
   char* env_snaplen = getenv("SNAPLEN");
   if (env_snaplen != nullptr) {
     snaplen = atol(env_snaplen);
     if (snaplen == 0 || snaplen > RW_MAX_SNAPLEN) {
-      snaplen = DEFAULT_SNAPLEN;
-      cout << "Invalid snaplen value, reset to default " << DEFAULT_SNAPLEN << endl;
+      snaplen = KINDLING_DEFAULT_SNAPLEN;
+      cout << "Invalid snaplen value, reset to default " << KINDLING_DEFAULT_SNAPLEN << endl;
     }
   }
 

--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -107,6 +107,22 @@ void set_eventmask(sinsp* inspector) {
   }
 }
 
+void set_snaplen(sinsp* inspector) {
+  uint32_t snaplen = 80;
+
+  char* env_snaplen = getenv("SNAPLEN");
+  if (env_snaplen != nullptr) {
+    snaplen = atol(env_snaplen);
+    if (snaplen == 0 || snaplen > RW_MAX_SNAPLEN) {
+      snaplen = RW_SNAPLEN;
+      cout << "Invalid snaplen value, reset to default " <<  RW_SNAPLEN << endl;
+    }
+  }
+  
+  cout << "Set snaplen to value: " << snaplen << endl;
+  inspector->set_snaplen(snaplen);
+}
+
 int init_probe() {
   int argc = 1;
   QCoreApplication app(argc, 0);
@@ -134,7 +150,7 @@ int init_probe() {
     inspector = new sinsp();
     formatter = new sinsp_evt_formatter(inspector, output_format);
     inspector->set_hostname_and_port_resolution_mode(false);
-    inspector->set_snaplen(1000);
+    set_snaplen(inspector);
     suppress_events_comm(inspector);
     inspector->open("");
     set_eventmask(inspector);


### PR DESCRIPTION
Signed-off-by: sanyangji <songyujie@zju.edu.cn>

## Description
Config `snaplen` is used to control max length of syscall data buffer, for example, the length of data of syscall write / read.
Default value: 80
Max value: 65,000
Usage: export as an environment value in the format of `SNAPLEN`.
```
# kindling-deploy.yml
        env:
        - name: HOST_PROC
          value: /host/proc
        - name: PL_HOST_PATH
          value: /host
        - name: SYSDIG_HOST_ROOT
          value: /host
        - name: SNAPLEN
          value: "1000"
```
## Related Issue
#314 mysql协议的sql显示不全 
#324 Support to configure snaplen through startup args