### PR TITLE
Add the missed latency field for cgoEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 
 ### Bug fixes
+- Add the missed latency field for `cgoEvent` to fix the bug where the `request_sent_time` in `single_net_request_metric_group` is always 0. ([#394](https://github.com/KindlingProject/kindling/pull/394))
 - Fix the wrong thread name in the trace profiling function. ([#385])(https://github.com/KindlingProject/kindling/pull/385)
 - Remove "reset" method of ScheduledTaskRoutine to fix a potential dead-lock issue. ([#369])(https://github.com/KindlingProject/kindling/pull/369)
 - Fix the bug where the pod metadata with persistent IP in the map is deleted incorrectly due to the deleting mechanism with a delay. ([#374](https://github.com/KindlingProject/kindling/pull/374))

--- a/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
+++ b/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
@@ -15,12 +15,13 @@ import (
 	"time"
 	"unsafe"
 
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
 	"github.com/Kindling-project/kindling/collector/pkg/component"
 	analyzerpackage "github.com/Kindling-project/kindling/collector/pkg/component/analyzer"
 	"github.com/Kindling-project/kindling/collector/pkg/component/receiver"
 	"github.com/Kindling-project/kindling/collector/pkg/model"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -65,7 +66,7 @@ func (r *CgoReceiver) Start() error {
 		return fmt.Errorf("fail to init probe")
 	}
 	time.Sleep(2 * time.Second)
-	r.subEvent()
+	_ = r.subEvent()
 	// Wait for the C routine running
 	time.Sleep(2 * time.Second)
 	go r.consumeEvents()
@@ -140,6 +141,7 @@ func convertEvent(cgoEvent *CKindlingEventForGo) *model.KindlingEvent {
 	ev.Ctx.FdInfo.Destination = uint64(cgoEvent.context.fdInfo.destination)
 
 	ev.ParamsNumber = uint16(cgoEvent.paramsNumber)
+	ev.Latency = uint64(cgoEvent.latency)
 	for i := 0; i < int(ev.ParamsNumber); i++ {
 		ev.UserAttributes[i].Key = C.GoString(cgoEvent.userAttributes[i].key)
 		userAttributesLen := cgoEvent.userAttributes[i].len


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add the missed latency field for `cgoEvent` to fix the bug where the `request_sent_time` in `single_net_request_metric_group ` is always 0.