### PR TITLE
Remove mps in getRecordWithSinglePair function to improve readability

### DIFF
--- a/collector/pkg/component/analyzer/network/message_pair.go
+++ b/collector/pkg/component/analyzer/network/message_pair.go
@@ -291,6 +291,7 @@ func (mps *messagePairs) getResponseSize() uint64 {
 type messagePair struct {
 	request  *model.KindlingEvent
 	response *model.KindlingEvent
+	natTuple *conntracker.IPTranslation
 }
 
 func (mp *messagePair) getSentTime() int64 {


### PR DESCRIPTION
Signed-off-by: huxiangyuan <huxiangyuan@harmonycloud.cn>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make method getRecordWithSinglePair easy to understand

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
[network analyzer nil pointer](https://github.com/KindlingProject/kindling/issues/401)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->