### PR TITLE
Add commit/set autocommit for mysql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 1. All notable changes to this project will be documented in this file.
 2. Records in this file are not identical to the title of their Pull Requests. A detailed description is necessary for understanding what changes are and why they are made.
 
+## Unreleased
+### New features
+
+### Enhancements
+- Add mysql statement commit/set autocommit. ([#417](https://github.com/KindlingProject/kindling/pull/417))
+
+### Bug fixes
+
+
 ## v0.6.0 - 2022-12-21
 ### New features
 - Support to configure `snaplen` through startup args.([#387](https://github.com/KindlingProject/kindling/pull/387))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### New features
 
 ### Enhancements
-- Add mysql statement commit/set autocommit. ([#417](https://github.com/KindlingProject/kindling/pull/417))
+- Support to identify the MySQL protocol with statements `commit` and `set`. ([#417](https://github.com/KindlingProject/kindling/pull/417))
+
 
 ### Bug fixes
 

--- a/collector/pkg/component/analyzer/network/network_analyzer_test.go
+++ b/collector/pkg/component/analyzer/network/network_analyzer_test.go
@@ -31,6 +31,7 @@ func TestHttpProtocol(t *testing.T) {
 
 func TestMySqlProtocol(t *testing.T) {
 	testProtocol(t, "mysql/server-event.yml",
+		"mysql/server-trace-commit.yml",
 		"mysql/server-trace-query-split.yml",
 		"mysql/server-trace-query.yml")
 }

--- a/collector/pkg/component/analyzer/network/protocol/mysql/mysql_request.go
+++ b/collector/pkg/component/analyzer/network/protocol/mysql/mysql_request.go
@@ -80,6 +80,8 @@ var sqlPrefixs = []string{
 	"drop",
 	"create",
 	"alter",
+	"set",
+	"commit",
 }
 
 func isSql(sql string) bool {

--- a/collector/pkg/component/analyzer/network/protocol/mysql/tools/sql_merger.go
+++ b/collector/pkg/component/analyzer/network/protocol/mysql/tools/sql_merger.go
@@ -22,7 +22,7 @@ type SqlParser struct {
 }
 
 func NewSqlMerger() SqlMerger {
-	factory := make([]SqlParser, 7)
+	factory := make([]SqlParser, 9)
 	factory[0] = newSqlParser("select", "from")
 	factory[1] = newSqlParser("insert", "into")
 	factory[2] = newSqlParser("update", "update")
@@ -30,6 +30,8 @@ func NewSqlMerger() SqlMerger {
 	factory[4] = newSqlParser("drop", "index|table|database")
 	factory[5] = newSqlParser("create", "index|table|database")
 	factory[6] = newSqlParser("alter", "table")
+	factory[7] = newSqlParser("set", "set")
+	factory[8] = newSqlParser("commit", "commit")
 
 	return SqlMerger{
 		factory: factory,

--- a/collector/pkg/component/analyzer/network/protocol/mysql/tools/sql_merger_test.go
+++ b/collector/pkg/component/analyzer/network/protocol/mysql/tools/sql_merger_test.go
@@ -74,6 +74,23 @@ func TestSqlMerger_InsertSql(t *testing.T) {
 				},
 			},
 		},
+		{
+			operator: "commit",
+			datas: map[string][]string{
+				"commit *": {
+					"commit",
+				},
+			},
+		},
+		{
+			operator: "set",
+			datas: map[string][]string{
+				"set *": {
+					"SET autocommit=0",
+					"SET autocommit=1",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-commit.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-commit.yml
@@ -1,0 +1,206 @@
+# 0--100---200--300-----500---600------700----800----900
+#    WRITE READ
+#               WRITE   READ
+#                             WRITE    READ
+#                                            WRITE   READ
+trace:
+  key: commit
+  requests:
+    -
+      name: "recvfrom"
+      timestamp: 100000000
+      user_attributes:
+        latency: 100
+        res: 21
+        data:
+          - "hex|11000000"
+          - "03|SET autocommit=0"
+    -
+      name: "recvfrom"
+      timestamp: 100000300
+      user_attributes:
+        latency: 100
+        res: 53
+        data:
+          - "hex|31000000"
+          - "03|INSERT INTO student  ( name )  VALUES  ( 'aaa' )"
+    -
+      name: "recvfrom"
+      timestamp: 100000600
+      user_attributes:
+        latency: 30
+        res: 11
+        data:
+          - "hex|31000000"
+          - "03|commit"
+    -
+      name: "recvfrom"
+      timestamp: 100000800
+      user_attributes:
+        latency: 40
+        res: 21
+        data:
+          - "hex|11000000"
+          - "03|SET autocommit=1"
+  responses:
+    -
+      name: "sendto"
+      timestamp: 100000200
+      user_attributes:
+        latency: 50
+        res: 11
+        data:
+          - "hex|0700000100000000000000"
+    -
+      name: "sendto"
+      timestamp: 100000500
+      user_attributes:
+        latency: 30
+        res: 11
+        data:
+          - "hex|070000010001f101000000"
+    -
+      name: "sendto"
+      timestamp: 100000900
+      user_attributes:
+        latency: 40
+        res: 11
+        data:
+          - "hex|0700000100000000000000"
+    -
+      name: "sendto"
+      timestamp: 100000700
+      user_attributes:
+        latency: 10
+        res: 11
+        data:
+          - "hex|0700000100000002000000"    
+  expects:
+    -
+      Timestamp: 99999900
+      Values:
+        request_total_time: 300
+        connect_time: 0
+        request_sent_time: 100
+        waiting_ttfb_time: 150
+        content_download_time: 50
+        request_io: 21
+        response_io: 11
+      Labels:
+        comm: "mysqld"
+        pid: 903
+        request_tid: 2744
+        response_tid: 2744
+        src_ip: "127.0.0.1"
+        src_port: 49368
+        dst_ip: "127.0.0.1"
+        dst_port: 3306
+        dnat_ip: ""
+        dnat_port: -1
+        container_id: ""
+        is_slow: false
+        is_server: true
+        protocol: "mysql"
+        content_key: "set *"
+        sql: "SET autocommit=0"
+        request_payload: ".....SET autocommit=0"
+        response_payload: "..........."
+        is_error: false
+        error_type: 0
+        end_timestamp: 100000200
+    -
+      Timestamp: 100000200
+      Values:
+        request_total_time: 300
+        connect_time: 0
+        request_sent_time: 100
+        waiting_ttfb_time: 170
+        content_download_time: 30
+        request_io: 53
+        response_io: 11
+      Labels:
+        comm: "mysqld"
+        pid: 903
+        request_tid: 2744
+        response_tid: 2744
+        src_ip: "127.0.0.1"
+        src_port: 49368
+        dst_ip: "127.0.0.1"
+        dst_port: 3306
+        dnat_ip: ""
+        dnat_port: -1
+        container_id: ""
+        is_slow: false
+        is_server: true
+        protocol: "mysql"
+        content_key: "insert student *"
+        sql: "INSERT INTO student  ( name )  VALUES  ( 'aaa' )"
+        request_payload: "1....INSERT INTO student  ( name )  VALUES  ( 'aaa' )"
+        response_payload: "..........."
+        is_error: false
+        error_type: 0
+        end_timestamp: 100000500
+    -
+      Timestamp: 100000570
+      Values:
+        request_total_time: 130
+        connect_time: 0
+        request_sent_time: 30
+        waiting_ttfb_time: 90
+        content_download_time: 10
+        request_io: 11
+        response_io: 11
+      Labels:
+        comm: "mysqld"
+        pid: 903
+        request_tid: 2744
+        response_tid: 2744
+        src_ip: "127.0.0.1"
+        src_port: 49368
+        dst_ip: "127.0.0.1"
+        dst_port: 3306
+        dnat_ip: ""
+        dnat_port: -1
+        container_id: ""
+        is_slow: false
+        is_server: true
+        protocol: "mysql"
+        content_key: "commit *"
+        sql: "commit"
+        request_payload: "1....commit"
+        response_payload: "..........."
+        is_error: false
+        error_type: 0
+        end_timestamp: 100000700
+    -
+      Timestamp: 100000760
+      Values:
+        request_total_time: 140
+        connect_time: 0
+        request_sent_time: 40
+        waiting_ttfb_time: 60
+        content_download_time: 40
+        request_io: 21
+        response_io: 11
+      Labels:
+        comm: "mysqld"
+        pid: 903
+        request_tid: 2744
+        response_tid: 2744
+        src_ip: "127.0.0.1"
+        src_port: 49368
+        dst_ip: "127.0.0.1"
+        dst_port: 3306
+        dnat_ip: ""
+        dnat_port: -1
+        container_id: ""
+        is_slow: false
+        is_server: true
+        protocol: "mysql"
+        content_key: "set *"
+        sql: "SET autocommit=1"
+        request_payload: ".....SET autocommit=1"
+        response_payload: "..........."
+        is_error: false
+        error_type: 0
+        end_timestamp: 100000900


### PR DESCRIPTION
Signed-off-by: huxiangyuan <huxiangyuan@harmonycloud.cn>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Mysql add commit、set autocommit=1 parse operation

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
=== RUN   TestMySqlProtocol/query
--- PASS: TestMySqlProtocol (0.00s)
    --- PASS: TestMySqlProtocol/commit (0.00s)