### PR TITLE
Fix the bug that cpuanalyzer missed some trigger events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@
 - When using the file writer in `cameraexporter`, we rotate files in chronological order now and rotate half of files one time. ([#420](https://github.com/KindlingProject/kindling/pull/420))
 - Support to identify the MySQL protocol with statements `commit` and `set`. ([#417](https://github.com/KindlingProject/kindling/pull/417))
 
-
 ### Bug fixes
-
+- Fix the bug that cpuanalyzer missed some trigger events due to the incorrect variable reference. This may cause some traces can't correlate with on/off CPU data. ([#424](https://github.com/KindlingProject/kindling/pull/424))
 
 ## v0.6.0 - 2022-12-21
 ### New features

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -140,7 +140,8 @@ exporters:
     # Effective when storage is "file"
     file_config:
       storage_path: /tmp/kindling
-      max_file_count: 50
+      # Max file count for each process
+      max_file_count_each_process: 50
     # Effective when storage is "elasticsearch"
     es_config:
       es_host: http://10.10.10.10:9200

--- a/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
@@ -26,7 +26,7 @@ type CpuAnalyzer struct {
 	// { pid: routine }
 	sendEventsRoutineMap sync.Map
 	routineSize          *atomic.Int32
-	lock                 sync.Mutex
+	lock                 sync.RWMutex
 	telemetry            *component.TelemetryTools
 	tidExpiredQueue      *tidDeleteQueue
 	nextConsumers        []consumer.Consumer

--- a/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
@@ -225,8 +225,8 @@ func (ca *CpuAnalyzer) PutEventToSegments(pid uint32, tid uint32, threadName str
 				}
 			}
 		}
-
-		timeSegments.updateThreadName(threadName) //update the thread name immediatly
+		//update the thread name immediately
+		timeSegments.updateThreadName(threadName)
 		for i := startOffset; i <= endOffset && i < maxSegmentSize; i++ {
 			val := timeSegments.Segments.GetByIndex(i)
 			segment := val.(*Segment)

--- a/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
@@ -189,7 +189,6 @@ func (ca *CpuAnalyzer) PutEventToSegments(pid uint32, tid uint32, threadName str
 		// If the timeSegment is full, we clear half of its elements.
 		// Note the offset will be times of maxSegmentSize when no events with this tid come for long time,
 		// so the timeSegment will be cleared multiple times until it can accommodate the events.
-		// TODO: clear the whole elements if startOffset>=1.5*maxSegmentSize
 		if startOffset >= maxSegmentSize || endOffset > maxSegmentSize {
 			if startOffset*2 >= 3*maxSegmentSize {
 				// clear all elements
@@ -225,7 +224,7 @@ func (ca *CpuAnalyzer) PutEventToSegments(pid uint32, tid uint32, threadName str
 				}
 			}
 		}
-		//update the thread name immediately
+		// Update the thread name immediately
 		timeSegments.updateThreadName(threadName)
 		for i := startOffset; i <= endOffset && i < maxSegmentSize; i++ {
 			val := timeSegments.Segments.GetByIndex(i)

--- a/collector/pkg/component/analyzer/cpuanalyzer/send_trigger.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/send_trigger.go
@@ -90,8 +90,8 @@ func (t *SendEventsTask) run() {
 }
 
 func (ca *CpuAnalyzer) sendEvents(keyElements *model.AttributeMap, pid uint32, startTime uint64, endTime uint64) {
-	ca.lock.Lock()
-	defer ca.lock.Unlock()
+	ca.lock.RLock()
+	defer ca.lock.RUnlock()
 
 	maxSegmentSize := ca.cfg.GetSegmentSize()
 	tidCpuEvents, exist := ca.cpuPidEvents[pid]
@@ -105,7 +105,7 @@ func (ca *CpuAnalyzer) sendEvents(keyElements *model.AttributeMap, pid uint32, s
 
 	for _, timeSegments := range tidCpuEvents {
 		if endTimeSecond < timeSegments.BaseTime || startTimeSecond > timeSegments.BaseTime+uint64(maxSegmentSize) {
-			ca.telemetry.Logger.Debugf("pid=%d tid=%d events are beyond the time windows. BaseTimeSecond=%d, "+
+			ca.telemetry.Logger.Infof("pid=%d tid=%d events are beyond the time windows. BaseTimeSecond=%d, "+
 				"startTimeSecond=%d, endTimeSecond=%d", pid, timeSegments.Tid, timeSegments.BaseTime, startTimeSecond, endTimeSecond)
 			continue
 		}

--- a/collector/pkg/component/analyzer/cpuanalyzer/send_trigger.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/send_trigger.go
@@ -58,7 +58,9 @@ func (ca *CpuAnalyzer) ReceiveSendSignal() {
 		for _, nexConsumer := range ca.nextConsumers {
 			_ = nexConsumer.Consume(sendContent.OriginalData)
 		}
-		task := &SendEventsTask{0, ca, &sendContent}
+		// Copy the value and then get its pointer to create a new task
+		triggerEvent := sendContent
+		task := &SendEventsTask{0, ca, &triggerEvent}
 		expiredCallback := func() {
 			ca.routineSize.Dec()
 		}

--- a/collector/pkg/component/analyzer/cpuanalyzer/send_trigger_test.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/send_trigger_test.go
@@ -1,0 +1,36 @@
+package cpuanalyzer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPointer(t *testing.T) {
+	queue := make(chan MyTask, 10)
+	for i := 0; i < 5; i++ {
+		queue <- MyTask{i}
+	}
+	close(queue)
+	array := make([]Task, 0)
+	for v := range queue {
+		// Copy the value and the get its pointer
+		tmp := v
+		array = append(array, &tmp)
+	}
+	for i, v := range array {
+		assert.Equal(t, i, v.getAge())
+	}
+}
+
+type MyTask struct {
+	age int
+}
+
+func (t *MyTask) getAge() int {
+	return t.age
+}
+
+type Task interface {
+	getAge() int
+}

--- a/collector/pkg/component/consumer/exporter/cameraexporter/config.go
+++ b/collector/pkg/component/consumer/exporter/cameraexporter/config.go
@@ -19,16 +19,16 @@ type esConfig struct {
 type fileConfig struct {
 	// StoragePath is the ABSOLUTE path of the directory where the profile file should be saved
 	StoragePath string `mapstructure:"storage_path"`
-	// Storage constrains
-	MaxFileCount int `mapstructure:"max_file_count"`
+	// Storage constrains for each process
+	MaxFileCountEachProcess int `mapstructure:"max_file_count_each_process"`
 }
 
 func NewDefaultConfig() *Config {
 	return &Config{
 		Storage: storageFile,
 		FileConfig: &fileConfig{
-			StoragePath:  "/tmp/kindling/",
-			MaxFileCount: 50,
+			StoragePath:             "/tmp/kindling/",
+			MaxFileCountEachProcess: 50,
 		},
 	}
 }

--- a/collector/pkg/component/consumer/exporter/cameraexporter/filewriter.go
+++ b/collector/pkg/component/consumer/exporter/cameraexporter/filewriter.go
@@ -111,7 +111,7 @@ func (fw *fileWriter) writeFile(baseDir string, fileName string, group *model.Da
 
 func (fw *fileWriter) rotateFiles(baseDir string) error {
 	// No constrains set
-	if fw.config.MaxFileCount <= 0 {
+	if fw.config.MaxFileCountEachProcess <= 0 {
 		return nil
 	}
 	// Get all files path
@@ -120,14 +120,14 @@ func (fw *fileWriter) rotateFiles(baseDir string) error {
 		return fmt.Errorf("can't get files list: %w", err)
 	}
 	// No need to rotate
-	if len(toBeRotated) < fw.config.MaxFileCount {
+	if len(toBeRotated) < fw.config.MaxFileCountEachProcess {
 		return nil
 	}
 	// Remove the older files and remove half of them one time to decrease the frequency
 	// of deleting files. Note this is different from rotating log files. We could delete
 	// one file at a time for log files because the action "rotate" is in a low frequency
 	// in that case.
-	toBeRotated = toBeRotated[:len(toBeRotated)-fw.config.MaxFileCount/2+1]
+	toBeRotated = toBeRotated[:len(toBeRotated)-fw.config.MaxFileCountEachProcess/2+1]
 	// Remove the stale files asynchronously
 	go func() {
 		for _, dirEntry := range toBeRotated {

--- a/collector/pkg/component/consumer/exporter/cameraexporter/filewriter_test.go
+++ b/collector/pkg/component/consumer/exporter/cameraexporter/filewriter_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestWriteTrace(t *testing.T) {
 	fileConfig := &fileConfig{
-		StoragePath:  "/tmp/kindling/",
-		MaxFileCount: 20,
+		StoragePath:             "/tmp/kindling/",
+		MaxFileCountEachProcess: 20,
 	}
 	writer, err := newFileWriter(fileConfig, component.NewDefaultTelemetryTools().Logger)
 	if err != nil {
@@ -36,7 +36,7 @@ func TestWriteTrace(t *testing.T) {
 	filePath := writer.pidFilePath(pathElements.WorkloadName, pathElements.PodName, pathElements.ContainerName, pathElements.Pid)
 	filesName, err := getDirEntryInTimeOrder(filePath)
 	assert.NoError(t, err)
-	assert.Equal(t, fileConfig.MaxFileCount/2+2, len(filesName))
+	assert.Equal(t, fileConfig.MaxFileCountEachProcess/2+2, len(filesName))
 }
 
 func traceData(pid int64, timestamp uint64) *model.DataGroup {

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -139,7 +139,8 @@ exporters:
     # Effective when storage is "file"
     file_config:
       storage_path: /tmp/kindling
-      max_file_count: 50
+      # Max file count for each process
+      max_file_count_each_process: 50
     # Effective when storage is "elasticsearch"
     es_config:
       es_host: http://10.10.10.10:9200


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix the bug that `cpuanalyzer` missed some trigger events due to the incorrect variable reference. This may cause some traces can't correlate with on/off CPU data.
