### PR TITLE
Make the timestamp of the profiling files readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New features
 
 ### Enhancements
+- Rename the camera profiling file to make the timestamp of the profiling files readable. ([#434](https://github.com/KindlingProject/kindling/pull/434))
 - When using the file writer in `cameraexporter`, we rotate files in chronological order now and rotate half of files one time. ([#420](https://github.com/KindlingProject/kindling/pull/420))
 - Support to identify the MySQL protocol with statements `commit` and `set`. ([#417](https://github.com/KindlingProject/kindling/pull/417))
 

--- a/collector/pkg/component/consumer/exporter/cameraexporter/datehelper.go
+++ b/collector/pkg/component/consumer/exporter/cameraexporter/datehelper.go
@@ -1,0 +1,24 @@
+package cameraexporter
+
+import (
+	"strconv"
+	"time"
+)
+
+func getDateString(timestamp int64) string {
+	timeUnix := time.Unix(0, timestamp)
+	year, month, day := timeUnix.Date()
+	hour, minute, second := timeUnix.Clock()
+	nano := timestamp % 1e9
+	return dateToString(year) + dateToString(int(month)) + dateToString(day) +
+		dateToString(hour) + dateToString(minute) + dateToString(second) +
+		"." + dateToString(int(nano))
+}
+
+func dateToString(date int) string {
+	if date >= 0 && date <= 9 {
+		return "0" + strconv.FormatInt(int64(date), 10)
+	} else {
+		return strconv.FormatInt(int64(date), 10)
+	}
+}

--- a/collector/pkg/component/consumer/exporter/cameraexporter/datehelper_test.go
+++ b/collector/pkg/component/consumer/exporter/cameraexporter/datehelper_test.go
@@ -1,0 +1,13 @@
+package cameraexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDateString(t *testing.T) {
+	nanoseconds := 1672887314101975422
+	dateString := getDateString(int64(nanoseconds))
+	assert.Equal(t, "20230105105514.101975422", dateString)
+}

--- a/collector/pkg/component/consumer/exporter/cameraexporter/filewriter.go
+++ b/collector/pkg/component/consumer/exporter/cameraexporter/filewriter.go
@@ -61,7 +61,7 @@ func getFileName(protocol string, contentKey string, timestamp uint64, isServer 
 		isServerString = "false"
 	}
 	encodedContent := base64.URLEncoding.EncodeToString([]byte(contentKey))
-	return protocol + "_" + encodedContent + "_" + strconv.FormatUint(timestamp, 10) + "_" + isServerString
+	return getDateString(int64(timestamp)) + "_" + protocol + "_" + encodedContent + "_" + isServerString
 }
 
 func (fw *fileWriter) writeTrace(group *model.DataGroup) {


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Make the timestamp of the profiling files readable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
=== RUN   TestGetDateString
--- PASS: TestGetDateString (0.00s)
=== RUN   TestWriteTrace
--- PASS: TestWriteTrace (0.09s)
PASS
```