### PR TITLE
[cpuanalyzer]Add an option edge_events_window_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New features
 
 ### Enhancements
+- Add an option edge_events_window_size to allow users to reduce the size of the files by narrowing the time window where seats the edge events. ([#437](https://github.com/KindlingProject/kindling/pull/437))
 - Rename the camera profiling file to make the timestamp of the profiling files readable. ([#434](https://github.com/KindlingProject/kindling/pull/434))
 - When using the file writer in `cameraexporter`, we rotate files in chronological order now and rotate half of files one time. ([#420](https://github.com/KindlingProject/kindling/pull/420))
 - Support to identify the MySQL protocol with statements `commit` and `set`. ([#417](https://github.com/KindlingProject/kindling/pull/417))

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -37,7 +37,7 @@ analyzers:
     # The elder segments will be overwritten by the newer ones, so don't set it too low.
     segment_size: 40
     # edge_events_window_size is the size of the duration window that seats the edge events.
-    # The unit is seconds. The greater it is, the more data will be stored.
+    # The unit is second. The greater it is, the more data will be stored.
     edge_events_window_size: 2
   tcpconnectanalyzer:
     channel_size: 10000

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -33,7 +33,12 @@ receivers:
       - name: tracepoint-procexit
 analyzers:
   cpuanalyzer:
+    # segment_size defines how many segments(seconds) can be cached to wait for sending.
+    # The elder segments will be overwritten by the newer ones, so don't set it too low.
     segment_size: 40
+    # edge_events_window_size is the size of the duration window that seats the edge events.
+    # The unit is seconds. The greater it is, the more data will be stored.
+    edge_events_window_size: 2
   tcpconnectanalyzer:
     channel_size: 10000
     wait_event_second: 10

--- a/collector/internal/application/application.go
+++ b/collector/internal/application/application.go
@@ -4,6 +4,9 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/spf13/viper"
+	"go.uber.org/multierr"
+
 	"github.com/Kindling-project/kindling/collector/pkg/component"
 	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer"
 	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer/cpuanalyzer"
@@ -20,8 +23,6 @@ import (
 	"github.com/Kindling-project/kindling/collector/pkg/component/controller"
 	"github.com/Kindling-project/kindling/collector/pkg/component/receiver"
 	"github.com/Kindling-project/kindling/collector/pkg/component/receiver/cgoreceiver"
-	"github.com/spf13/viper"
-	"go.uber.org/multierr"
 )
 
 type Application struct {
@@ -73,14 +74,10 @@ func (a *Application) Shutdown() error {
 	return multierr.Combine(a.receiver.Shutdown(), a.analyzerManager.ShutdownAll(a.telemetry.GetGlobalTelemetryTools().Logger))
 }
 
-func initFlags() error {
-	return nil
-}
-
 func (a *Application) registerFactory() {
 	a.componentsFactory.RegisterReceiver(cgoreceiver.Cgo, cgoreceiver.NewCgoReceiver, &cgoreceiver.Config{})
 	a.componentsFactory.RegisterAnalyzer(network.Network.String(), network.NewNetworkAnalyzer, &network.Config{})
-	a.componentsFactory.RegisterAnalyzer(cpuanalyzer.CpuProfile.String(), cpuanalyzer.NewCpuAnalyzer, &cpuanalyzer.Config{})
+	a.componentsFactory.RegisterAnalyzer(cpuanalyzer.CpuProfile.String(), cpuanalyzer.NewCpuAnalyzer, cpuanalyzer.NewDefaultConfig())
 	a.componentsFactory.RegisterProcessor(k8sprocessor.K8sMetadata, k8sprocessor.NewKubernetesProcessor, &k8sprocessor.DefaultConfig)
 	a.componentsFactory.RegisterExporter(otelexporter.Otel, otelexporter.NewExporter, &otelexporter.Config{})
 	a.componentsFactory.RegisterAnalyzer(tcpmetricanalyzer.TcpMetric.String(), tcpmetricanalyzer.NewTcpMetricAnalyzer, &tcpmetricanalyzer.Config{})
@@ -99,7 +96,7 @@ func (a *Application) readInConfig(path string) error {
 	}
 	a.telemetry.ConstructConfig(a.viper)
 	err = a.componentsFactory.ConstructConfig(a.viper)
-	a.controllerFactory.ConstructConfig(a.viper, a.telemetry.GetGlobalTelemetryTools())
+	_ = a.controllerFactory.ConstructConfig(a.viper, a.telemetry.GetGlobalTelemetryTools())
 	if err != nil {
 		return fmt.Errorf("error happened while constructing config: %w", err)
 	}

--- a/collector/pkg/component/analyzer/cpuanalyzer/config.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/config.go
@@ -1,17 +1,17 @@
 package cpuanalyzer
 
-const (
-	defaultSegmentSize = 40
-)
-
 type Config struct {
+	// SegmentSize defines how many segments(seconds) can be cached to wait for sending.
+	// The elder segments will be overwritten by the newer ones, so don't set it too low.
 	SegmentSize int `mapstructure:"segment_size"`
+	// EdgeEventsWindowSize is the size of the duration window that seats the edge events.
+	// The unit is seconds. The greater it is, the more data will be stored.
+	EdgeEventsWindowSize int `mapstructure:"edge_events_window_size"`
 }
 
-func (cfg *Config) GetSegmentSize() int {
-	if cfg.SegmentSize > 0 {
-		return cfg.SegmentSize
-	} else {
-		return defaultSegmentSize
+func NewDefaultConfig() *Config {
+	return &Config{
+		SegmentSize:          40,
+		EdgeEventsWindowSize: 2,
 	}
 }

--- a/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
@@ -174,7 +174,7 @@ func (ca *CpuAnalyzer) PutEventToSegments(pid uint32, tid uint32, threadName str
 		ca.cpuPidEvents[pid] = tidCpuEvents
 	}
 	timeSegments, exist := tidCpuEvents[tid]
-	maxSegmentSize := ca.cfg.GetSegmentSize()
+	maxSegmentSize := ca.cfg.SegmentSize
 	if exist {
 		endOffset := int(event.EndTimestamp()/nanoToSeconds - timeSegments.BaseTime)
 		if endOffset < 0 {

--- a/collector/pkg/component/analyzer/cpuanalyzer/send_trigger.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/send_trigger.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Kindling-project/kindling/collector/pkg/model/constvalues"
 )
 
-var eventsWindowsDuration = 6 * time.Second
 var (
 	enableProfile bool
 	once          sync.Once
@@ -60,31 +59,36 @@ func (ca *CpuAnalyzer) ReceiveSendSignal() {
 		}
 		// Copy the value and then get its pointer to create a new task
 		triggerEvent := sendContent
-		task := &SendEventsTask{0, ca, &triggerEvent}
+		task := &SendEventsTask{
+			cpuAnalyzer:              ca,
+			triggerEvent:             &triggerEvent,
+			edgeEventsWindowDuration: time.Duration(ca.cfg.EdgeEventsWindowSize) * time.Second,
+		}
 		expiredCallback := func() {
 			ca.routineSize.Dec()
 		}
 		// The expired duration should be windowDuration+1 because the ticker and the timer are not started together.
-		NewAndStartScheduledTaskRoutine(1*time.Second, eventsWindowsDuration+1, task, expiredCallback)
+		NewAndStartScheduledTaskRoutine(1*time.Second, time.Duration(ca.cfg.EdgeEventsWindowSize)*time.Second+1, task, expiredCallback)
 		ca.routineSize.Inc()
 	}
 }
 
 type SendEventsTask struct {
-	tickerCount  int
-	cpuAnalyzer  *CpuAnalyzer
-	triggerEvent *SendTriggerEvent
+	tickerCount              int
+	cpuAnalyzer              *CpuAnalyzer
+	triggerEvent             *SendTriggerEvent
+	edgeEventsWindowDuration time.Duration
 }
 
 // |________________|______________|_________________|
-// 0      (5s)      1  (duration)  2      (5s)       3
+// 0  (edgeWindow)  1  (duration)  2  (edgeWindow)   3
 // 0: The start time of the windows where the events we need are.
 // 1: The start time of the "trace".
 // 2: The end time of the "trace". This is nearly equal to the creating time of the task.
 // 3: The end time of the windows where the events we need are.
 func (t *SendEventsTask) run() {
-	currentWindowsStartTime := uint64(t.tickerCount*1e9) + t.triggerEvent.StartTime - uint64(eventsWindowsDuration)
-	currentWindowsEndTime := uint64(t.tickerCount*1e9) + t.triggerEvent.StartTime + t.triggerEvent.SpendTime
+	currentWindowsStartTime := uint64(t.tickerCount)*uint64(time.Second) + t.triggerEvent.StartTime - uint64(t.edgeEventsWindowDuration)
+	currentWindowsEndTime := uint64(t.tickerCount)*uint64(time.Second) + t.triggerEvent.StartTime + t.triggerEvent.SpendTime
 	t.tickerCount++
 	// keyElements are used to correlate the cpuEvents with the trace.
 	keyElements := filepathhelper.GetFilePathElements(t.triggerEvent.OriginalData, t.triggerEvent.StartTime)
@@ -95,7 +99,7 @@ func (ca *CpuAnalyzer) sendEvents(keyElements *model.AttributeMap, pid uint32, s
 	ca.lock.RLock()
 	defer ca.lock.RUnlock()
 
-	maxSegmentSize := ca.cfg.GetSegmentSize()
+	maxSegmentSize := ca.cfg.SegmentSize
 	tidCpuEvents, exist := ca.cpuPidEvents[pid]
 	if !exist {
 		ca.telemetry.Logger.Infof("Not found the cpu events with the pid=%d, startTime=%d, endTime=%d",

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -37,7 +37,7 @@ analyzers:
 	  # The elder segments will be overwritten by the newer ones, so don't set it too low.
     segment_size: 40
     # edge_events_window_size is the size of the duration window that seats the edge events.
-	  # The unit is seconds. The greater it is, the more data will be stored.
+	  # The unit is second. The greater it is, the more data will be stored.
     edge_events_window_size: 2
   tcpconnectanalyzer:
     channel_size: 10000

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -34,10 +34,10 @@ receivers:
 analyzers:
   cpuanalyzer:
     # segment_size defines how many segments(seconds) can be cached to wait for sending.
-	  # The elder segments will be overwritten by the newer ones, so don't set it too low.
+    # The elder segments will be overwritten by the newer ones, so don't set it too low.
     segment_size: 40
     # edge_events_window_size is the size of the duration window that seats the edge events.
-	  # The unit is second. The greater it is, the more data will be stored.
+    # The unit is second. The greater it is, the more data will be stored.
     edge_events_window_size: 2
   tcpconnectanalyzer:
     channel_size: 10000

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -33,7 +33,12 @@ receivers:
       - name: tracepoint-procexit
 analyzers:
   cpuanalyzer:
+    # segment_size defines how many segments(seconds) can be cached to wait for sending.
+	  # The elder segments will be overwritten by the newer ones, so don't set it too low.
     segment_size: 40
+    # edge_events_window_size is the size of the duration window that seats the edge events.
+	  # The unit is seconds. The greater it is, the more data will be stored.
+    edge_events_window_size: 2
   tcpconnectanalyzer:
     channel_size: 10000
     wait_event_second: 10


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
`edge_events_window_size` is the size of the duration window that seats the edge events. The unit is second. The greater it is, the more data will be stored.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `filewriter` in `cameraexporter` has written too large files. This option is introduced to allow users to reduce the size of the files by narrowing the time window where seats the edge events.