### PR TITLE
Reduce item not found

### DIFF
--- a/collector/pkg/metadata/kubernetes/k8scache.go
+++ b/collector/pkg/metadata/kubernetes/k8scache.go
@@ -153,13 +153,13 @@ func (c *K8sMetaDataCache) GetContainerByIpPort(ip string, port uint32) (*K8sCon
 	if !ok {
 		// find the first pod whose network mode is not hostnetwork
 		for _, info := range portContainerInfo {
-			if !info.RefPodInfo.isHostNetwork && info.RefPodInfo.WorkloadKind != "daemonset" {
+			if !info.RefPodInfo.isHostNetwork {
 				return info, true
 			}
 		}
 		return nil, false
 	} else {
-		if !containerInfo.RefPodInfo.isHostNetwork && containerInfo.RefPodInfo.WorkloadKind != "daemonset" {
+		if !containerInfo.RefPodInfo.isHostNetwork {
 			return containerInfo, true
 		}
 		return nil, false
@@ -183,7 +183,7 @@ func (c *K8sMetaDataCache) GetPodByIp(ip string) (*K8sPodInfo, bool) {
 	}
 	// find the first pod whose network mode is not hostnetwork
 	for _, info := range portContainerInfo {
-		if !info.RefPodInfo.isHostNetwork && info.RefPodInfo.WorkloadKind != "daemonset" {
+		if !info.RefPodInfo.isHostNetwork {
 			return info.RefPodInfo, true
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Longhui li <longhui.li@woqutech.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
During the test, we found a lot of `NOT_FOUND_EXTERNAL` and `NOT_FOUND_INTERNAL`, which is not conducive to network analysis. Tracking and positioning found that partly due to the exclusion of `daemonset`, partly due to the fact that when there are multiple network cards, only the ip of one node is analyzed, and other traffic such as `cilium_host` is not clearly identified.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
None

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Yes
