### PR TITLE
Fix the bug that TCP metrics are not aggregated correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Support to identify the MySQL protocol with statements `commit` and `set`. ([#417](https://github.com/KindlingProject/kindling/pull/417))
 
 ### Bug fixes
+- Fix the bug that TCP metrics are not aggregated correctly. ([#444](https://github.com/KindlingProject/kindling/pull/444))
 - Fix the bug that cpuanalyzer missed some trigger events due to the incorrect variable reference. This may cause some traces can't correlate with on/off CPU data. ([#424](https://github.com/KindlingProject/kindling/pull/424))
 
 ## v0.6.0 - 2022-12-21

--- a/collector/pkg/aggregator/defaultaggregator/default_aggregator_test.go
+++ b/collector/pkg/aggregator/defaultaggregator/default_aggregator_test.go
@@ -34,7 +34,7 @@ func TestConcurrentAggregator(t *testing.T) {
 	go func() {
 		for i := 0; i < runLoop; i++ {
 			metricValues := []*model.Metric{
-				{Name: "duration", Data: &model.Metric_Int{Int: &model.Int{Value: duration}}},
+				{Name: "duration", Data: &model.Int{Value: duration}},
 			}
 			dataGroup := model.NewDataGroup("testMetric", labels, 0, metricValues...)
 			aggregatorInstance.Aggregate(dataGroup, labelSelectors)

--- a/collector/pkg/aggregator/defaultaggregator/value_recorder.go
+++ b/collector/pkg/aggregator/defaultaggregator/value_recorder.go
@@ -22,7 +22,9 @@ func newValueRecorder(recorderName string, aggKindMap map[string][]KindConfig) *
 	}
 }
 
-// Record is thread-safe, and return the result value
+// Record is thread-safe, and return the result value.
+// A recorder can record only the metrics that are same as the initial ones when using a same key.
+// But it allows to record different metrics with different keys.
 func (r *valueRecorder) Record(key *aggregator.LabelKeys, metricValues []*model.Metric, timestamp uint64) {
 	if key == nil {
 		return

--- a/collector/pkg/aggregator/defaultaggregator/value_recorder.go
+++ b/collector/pkg/aggregator/defaultaggregator/value_recorder.go
@@ -23,8 +23,8 @@ func newValueRecorder(recorderName string, aggKindMap map[string][]KindConfig) *
 }
 
 // Record is thread-safe, and return the result value.
-// A recorder can record only the metrics that are same as the initial ones when using a same key.
-// But it allows to record different metrics with different keys.
+// A recorder can record only the metrics that are the same as the initial ones when using the same key.
+// But it can record different metrics with different keys.
 func (r *valueRecorder) Record(key *aggregator.LabelKeys, metricValues []*model.Metric, timestamp uint64) {
 	if key == nil {
 		return

--- a/collector/pkg/component/analyzer/tcpmetricanalyzer/tcp_analyzer.go
+++ b/collector/pkg/component/analyzer/tcpmetricanalyzer/tcp_analyzer.go
@@ -3,6 +3,10 @@ package tcpmetricanalyzer
 import (
 	"fmt"
 
+	"github.com/hashicorp/go-multierror"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
 	"github.com/Kindling-project/kindling/collector/pkg/component"
 	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer"
 	"github.com/Kindling-project/kindling/collector/pkg/component/consumer"
@@ -10,9 +14,6 @@ import (
 	"github.com/Kindling-project/kindling/collector/pkg/model"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constlabels"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constnames"
-	"github.com/hashicorp/go-multierror"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -25,7 +26,7 @@ type TcpMetricAnalyzer struct {
 	telemetry   *component.TelemetryTools
 }
 
-func NewTcpMetricAnalyzer(cfg interface{}, telemetry *component.TelemetryTools, nextConsumers []consumer.Consumer) analyzer.Analyzer {
+func NewTcpMetricAnalyzer(_ interface{}, telemetry *component.TelemetryTools, nextConsumers []consumer.Consumer) analyzer.Analyzer {
 	retAnalyzer := &TcpMetricAnalyzer{
 		consumers: nextConsumers,
 		telemetry: telemetry,
@@ -101,7 +102,7 @@ func (a *TcpMetricAnalyzer) generateRtt(event *model.KindlingEvent) (*model.Data
 		return nil, nil
 	}
 	metric := model.NewIntMetric(constnames.TcpRttMetricName, int64(rtt))
-	return model.NewDataGroup(constnames.TcpMetricGroupName, labels, event.Timestamp, metric), nil
+	return model.NewDataGroup(constnames.TcpRttMetricGroupName, labels, event.Timestamp, metric), nil
 }
 
 func (a *TcpMetricAnalyzer) generateRetransmit(event *model.KindlingEvent) (*model.DataGroup, error) {
@@ -110,7 +111,7 @@ func (a *TcpMetricAnalyzer) generateRetransmit(event *model.KindlingEvent) (*mod
 		return nil, err
 	}
 	metric := model.NewIntMetric(constnames.TcpRetransmitMetricName, 1)
-	return model.NewDataGroup(constnames.TcpMetricGroupName, labels, event.Timestamp, metric), nil
+	return model.NewDataGroup(constnames.TcpRetransmitMetricGroupName, labels, event.Timestamp, metric), nil
 }
 
 func (a *TcpMetricAnalyzer) generateDrop(event *model.KindlingEvent) (*model.DataGroup, error) {
@@ -119,7 +120,7 @@ func (a *TcpMetricAnalyzer) generateDrop(event *model.KindlingEvent) (*model.Dat
 		return nil, err
 	}
 	metric := model.NewIntMetric(constnames.TcpDropMetricName, 1)
-	return model.NewDataGroup(constnames.TcpMetricGroupName, labels, event.Timestamp, metric), nil
+	return model.NewDataGroup(constnames.TcpDropMetricGroupName, labels, event.Timestamp, metric), nil
 }
 
 func (a *TcpMetricAnalyzer) getTupleLabels(event *model.KindlingEvent) (*model.AttributeMap, error) {

--- a/collector/pkg/component/consumer/exporter/otelexporter/instrument_test.go
+++ b/collector/pkg/component/consumer/exporter/otelexporter/instrument_test.go
@@ -6,16 +6,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Kindling-project/kindling/collector/pkg/component"
-	"github.com/Kindling-project/kindling/collector/pkg/component/consumer/exporter/tools/adapter"
-	"github.com/Kindling-project/kindling/collector/pkg/model"
-	"github.com/Kindling-project/kindling/collector/pkg/model/constlabels"
-	"github.com/Kindling-project/kindling/collector/pkg/model/constnames"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/histogram"
 	controller "go.opentelemetry.io/otel/sdk/metric/controller/basic"
 	otelprocessor "go.opentelemetry.io/otel/sdk/metric/processor/basic"
 	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
+
+	"github.com/Kindling-project/kindling/collector/pkg/component"
+	"github.com/Kindling-project/kindling/collector/pkg/component/consumer/exporter/tools/adapter"
+	"github.com/Kindling-project/kindling/collector/pkg/model"
+	"github.com/Kindling-project/kindling/collector/pkg/model/constlabels"
+	"github.com/Kindling-project/kindling/collector/pkg/model/constnames"
 )
 
 func Test_instrumentFactory_recordLastValue(t *testing.T) {
@@ -61,7 +62,7 @@ func Test_instrumentFactory_recordLastValue(t *testing.T) {
 		controller.WithResource(nil),
 	)
 
-	cont.Start(context.Background())
+	_ = cont.Start(context.Background())
 
 	ins := newInstrumentFactory(cont.Meter("test"), component.NewDefaultTelemetryTools(), nil)
 
@@ -77,7 +78,7 @@ func Test_instrumentFactory_recordLastValue(t *testing.T) {
 
 func makeTcpGroup(rttLatency int64) *model.DataGroup {
 	return model.NewDataGroup(
-		constnames.TcpMetricGroupName,
+		constnames.TcpRttMetricGroupName,
 		model.NewAttributeMapWithValues(
 			map[string]model.AttributeValue{
 				constlabels.SrcIp:           model.NewStringValue("src-ip"),
@@ -170,8 +171,8 @@ func Test_instrumentFactory_recordTraceAsMetric(t *testing.T) {
 					t1 = lastTraceAsMetric[i]
 
 					// value check
-					if metric, ok := t1.GetMetric(constnames.TraceAsMetric); ok {
-						if metric.GetInt().Value != randTime {
+					if m, ok := t1.GetMetric(constnames.TraceAsMetric); ok {
+						if m.GetInt().Value != randTime {
 							t.Errorf("Value check failed")
 						}
 					} else {

--- a/collector/pkg/component/consumer/exporter/otelexporter/otelexporter.go
+++ b/collector/pkg/component/consumer/exporter/otelexporter/otelexporter.go
@@ -7,10 +7,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/Kindling-project/kindling/collector/pkg/component"
-	"github.com/Kindling-project/kindling/collector/pkg/component/consumer/exporter"
-	"github.com/Kindling-project/kindling/collector/pkg/component/consumer/exporter/tools/adapter"
-	"github.com/Kindling-project/kindling/collector/pkg/model/constnames"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -29,6 +25,11 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+
+	"github.com/Kindling-project/kindling/collector/pkg/component"
+	"github.com/Kindling-project/kindling/collector/pkg/component/consumer/exporter"
+	"github.com/Kindling-project/kindling/collector/pkg/component/consumer/exporter/tools/adapter"
+	"github.com/Kindling-project/kindling/collector/pkg/model/constnames"
 )
 
 const (
@@ -43,17 +44,6 @@ const (
 )
 
 var serviceName string
-
-type labelKey struct {
-	metric          string
-	srcIp           string
-	dstIp           string
-	dstPort         int64
-	requestContent  string
-	responseContent string
-	statusCode      string
-	protocol        string
-}
 
 type OtelOutputExporters struct {
 	metricExporter exportmetric.Exporter
@@ -151,7 +141,8 @@ func NewExporter(config interface{}, telemetry *component.TelemetryTools) export
 					StorePodDetail:     cfg.AdapterConfig.NeedPodDetail,
 					StoreExternalSrcIP: cfg.AdapterConfig.StoreExternalSrcIP,
 				}),
-				adapter.NewSimpleAdapter([]string{constnames.TcpMetricGroupName, constnames.TcpConnectMetricGroupName}, customLabels),
+				adapter.NewSimpleAdapter([]string{constnames.TcpRttMetricGroupName, constnames.TcpRetransmitMetricGroupName,
+					constnames.TcpDropMetricGroupName, constnames.TcpConnectMetricGroupName}, customLabels),
 			},
 		}
 		go func() {
@@ -218,7 +209,8 @@ func NewExporter(config interface{}, telemetry *component.TelemetryTools) export
 					StorePodDetail:     cfg.AdapterConfig.NeedPodDetail,
 					StoreExternalSrcIP: cfg.AdapterConfig.StoreExternalSrcIP,
 				}),
-				adapter.NewSimpleAdapter([]string{constnames.TcpMetricGroupName, constnames.TcpConnectMetricGroupName}, customLabels),
+				adapter.NewSimpleAdapter([]string{constnames.TcpRttMetricGroupName, constnames.TcpRetransmitMetricGroupName,
+					constnames.TcpDropMetricGroupName, constnames.TcpConnectMetricGroupName}, customLabels),
 			},
 		}
 

--- a/collector/pkg/component/consumer/processor/aggregateprocessor/processor.go
+++ b/collector/pkg/component/consumer/processor/aggregateprocessor/processor.go
@@ -4,6 +4,8 @@ import (
 	"math/rand"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/Kindling-project/kindling/collector/pkg/aggregator"
 	"github.com/Kindling-project/kindling/collector/pkg/aggregator/defaultaggregator"
 	"github.com/Kindling-project/kindling/collector/pkg/component"
@@ -13,7 +15,6 @@ import (
 	"github.com/Kindling-project/kindling/collector/pkg/model"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constlabels"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constnames"
-	"go.uber.org/zap"
 )
 
 const Type = "aggregateprocessor"
@@ -124,7 +125,11 @@ func (p *AggregateProcessor) Consume(dataGroup *model.DataGroup) error {
 		dataGroup.Name = constnames.AggregatedNetRequestMetricGroup
 		p.aggregator.Aggregate(dataGroup, p.netRequestLabelSelectors)
 		return abnormalDataErr
-	case constnames.TcpMetricGroupName:
+	case constnames.TcpRttMetricGroupName:
+		fallthrough
+	case constnames.TcpRetransmitMetricGroupName:
+		fallthrough
+	case constnames.TcpDropMetricGroupName:
 		p.aggregator.Aggregate(dataGroup, p.tcpLabelSelectors)
 		return nil
 	case constnames.TcpConnectMetricGroupName:

--- a/collector/pkg/component/consumer/processor/k8sprocessor/kubernetes_processor.go
+++ b/collector/pkg/component/consumer/processor/k8sprocessor/kubernetes_processor.go
@@ -3,6 +3,8 @@ package k8sprocessor
 import (
 	"strconv"
 
+	"go.uber.org/zap"
+
 	"github.com/Kindling-project/kindling/collector/pkg/component"
 	"github.com/Kindling-project/kindling/collector/pkg/component/consumer"
 	"github.com/Kindling-project/kindling/collector/pkg/component/consumer/processor"
@@ -10,7 +12,6 @@ import (
 	"github.com/Kindling-project/kindling/collector/pkg/model"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constlabels"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constnames"
-	"go.uber.org/zap"
 )
 
 const (
@@ -76,7 +77,11 @@ func (p *K8sMetadataProcessor) Consume(dataGroup *model.DataGroup) error {
 	switch name {
 	case constnames.NetRequestMetricGroupName:
 		p.processNetRequestMetric(dataGroup)
-	case constnames.TcpMetricGroupName:
+	case constnames.TcpRttMetricGroupName:
+		fallthrough
+	case constnames.TcpRetransmitMetricGroupName:
+		fallthrough
+	case constnames.TcpDropMetricGroupName:
 		p.processTcpMetric(dataGroup)
 	default:
 		p.processNetRequestMetric(dataGroup)

--- a/collector/pkg/model/constnames/const.go
+++ b/collector/pkg/model/constnames/const.go
@@ -35,7 +35,9 @@ const (
 
 	CameraEventGroupName = "camera_event_group"
 
-	TcpMetricGroupName        = "tcp_metric_metric_group"
-	NodeMetricGroupName       = "node_metric_metric_group"
-	TcpConnectMetricGroupName = "tcp_connect_metric_group"
+	TcpRttMetricGroupName        = "tcp_rtt_metric_group"
+	TcpRetransmitMetricGroupName = "tcp_retransmit_metric_group"
+	TcpDropMetricGroupName       = "tcp_drop_metric_group"
+	NodeMetricGroupName          = "node_metric_metric_group"
+	TcpConnectMetricGroupName    = "tcp_connect_metric_group"
 )


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change the TCP metrics group name to fix the bug that these metrics are not aggregated correctly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A recorder can record only the metrics that are the same as the initial ones when using the same key. But it can record different metrics with different keys.
