### PR TITLE
Handle DeletedFinalStateUnknown when watching metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 1. All notable changes to this project will be documented in this file.
 2. Records in this file are not identical to the title of their Pull Requests. A detailed description is necessary for understanding what changes are and why they are made.
 
+## Unreleased
+### New features
+- 
+- 
+
+### Enhancements
+- 
+- 
+
+### Bug fixes
+- 
+- 
+- Fix the bug that the agent panics when it receives DeletedFinalStateUnknown by watching K8s metadata. ([#456](https://github.com/KindlingProject/kindling/pull/456))
+- 
+
 ## v0.7.0 - 2023-02-16
 ### New features
 - Add a new simplified chart to display the trace-profiling data. It mixes `span` with profiling and is more user-friendly. Try the demo now on the [website](http://kindling.harmonycloud.cn/).([#443](https://github.com/KindlingProject/kindling/pull/443))

--- a/collector/pkg/metadata/kubernetes/node_watch.go
+++ b/collector/pkg/metadata/kubernetes/node_watch.go
@@ -112,6 +112,18 @@ func UpdateNode(objOld interface{}, objNew interface{}) {
 }
 
 func DeleteNode(obj interface{}) {
-	node := obj.(*corev1.Node)
+	// Maybe get DeletedFinalStateUnknown instead of *corev1.Pod.
+	// Fix https://github.com/KindlingProject/kindling/issues/445
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return
+		}
+		node, ok = deletedState.Obj.(*corev1.Node)
+		if !ok {
+			return
+		}
+	}
 	globalNodeInfo.delete(node.Name)
 }

--- a/collector/pkg/metadata/kubernetes/pod_watch.go
+++ b/collector/pkg/metadata/kubernetes/pod_watch.go
@@ -323,7 +323,19 @@ func OnUpdate(objOld interface{}, objNew interface{}) {
 }
 
 func onDelete(obj interface{}) {
-	pod := obj.(*corev1.Pod)
+	// Maybe get DeletedFinalStateUnknown instead of *corev1.Pod.
+	// Fix https://github.com/KindlingProject/kindling/issues/445
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return
+		}
+		pod, ok = deletedState.Obj.(*corev1.Pod)
+		if !ok {
+			return
+		}
+	}
 	podInfo := &deletedPodInfo{
 		uid:          string(pod.UID),
 		name:         pod.Name,

--- a/collector/pkg/metadata/kubernetes/replicaset_watch.go
+++ b/collector/pkg/metadata/kubernetes/replicaset_watch.go
@@ -111,6 +111,18 @@ func OnUpdateReplicaSet(objOld interface{}, objNew interface{}) {
 }
 
 func onDeleteReplicaSet(obj interface{}) {
-	rs := obj.(*appv1.ReplicaSet)
+	// Maybe get DeletedFinalStateUnknown instead of *corev1.Pod.
+	// Fix https://github.com/KindlingProject/kindling/issues/445
+	rs, ok := obj.(*appv1.ReplicaSet)
+	if !ok {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return
+		}
+		rs, ok = deletedState.Obj.(*appv1.ReplicaSet)
+		if !ok {
+			return
+		}
+	}
 	globalRsInfo.deleteOwnerReference(mapKey(rs.Namespace, rs.Name))
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Handle DeletedFinalStateUnknown when watching pod, replicaset, node, and service. Same with https://github.com/kubernetes/kubernetes/pull/34694/files.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
#445