### PR TITLE
Fix the potential endless loop in the rocketmq parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@
 - 
 
 ### Enhancements
-- Improve Kindling Event log format.([#455](https://github.com/KindlingProject/kindling/pull/455))
+- Improve Kindling Event log format. ([#455](https://github.com/KindlingProject/kindling/pull/455))
 - 
 
 ### Bug fixes
-- Fix retransmission count is not consistent with the real value on Linux 4.7 or higher([#450](https://github.com/KindlingProject/kindling/pull/450))
+- Fix the potential endless loop in the rocketmq parser. ([#465](https://github.com/KindlingProject/kindling/pull/465))
+- Fix retransmission count is not consistent with the real value on Linux 4.7 or higher. ([#450](https://github.com/KindlingProject/kindling/pull/450))
+- Reduce the cases pods are not found when they are daemonset. ([#439](https://github.com/KindlingProject/kindling/pull/439) @llhhbc)
 - Collector subscribes `sendmmsg` events to fix the bug that some DNS requests are missed. ([#430](https://github.com/KindlingProject/kindling/pull/430))
 - Fix the bug that the agent panics when it receives DeletedFinalStateUnknown by watching K8s metadata. ([#456](https://github.com/KindlingProject/kindling/pull/456))
 - 

--- a/collector/pkg/component/analyzer/network/protocol/rocketmq/rocketmq_request_test.go
+++ b/collector/pkg/component/analyzer/network/protocol/rocketmq/rocketmq_request_test.go
@@ -1,0 +1,47 @@
+package rocketmq
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer/network/protocol"
+)
+
+func Test_parseHeader(t *testing.T) {
+	type args struct {
+		message *protocol.PayloadMessage
+		header  *rocketmqHeader
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "busy-loop",
+			args: args{
+				message: protocol.NewRequestMessage([]byte{
+					1, 23, 4, 20, 123, 213, 4, 2, 34, 12, 23, 1, 23, 4, 20, 123,
+					213, 4, 2, 34, 12, 0, 0, 0, 0, 20, 123, 213, 4, 254, 34, 12,
+					23, 1, 23, 4, 20, 123, 213, 4, 2, 34, 12, 23, 1, 23, 4, 20,
+					123, 213, 4, 2, 34, 12, 23}),
+				header: &rocketmqHeader{ExtFields: map[string]string{}},
+			},
+		},
+	}
+	finishCh := make(chan bool)
+	go func() {
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				parseHeader(tt.args.message, tt.args.header)
+			})
+		}
+		finishCh <- true
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("The test case didn't finish in 5 seconds.")
+	case <-finishCh:
+		return
+	}
+}


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Fix the potential endless loop in the rocketmq parser.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Before
```
=== RUN   Test_parseHeader
    rocketmq_request_test.go:43: The test case didn't finish in 5 seconds.
--- FAIL: Test_parseHeader (5.00s)
testing: warning: no tests to run
=== RUN   Test_parseHeader/busy-loop
FAIL
```
After
```
=== RUN   Test_parseHeader
=== RUN   Test_parseHeader/busy-loop
--- PASS: Test_parseHeader (0.00s)
    --- PASS: Test_parseHeader/busy-loop (0.00s)
PASS
```