### PR TITLE
Add an option WithMemory to opentelemetry's prometheus exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Unreleased 
 ### Enhancements
+- Add an option `WithMemory` to OpenTelemetry's Prometheus exporter. It allows users to control whether metrics that haven't been updated in the most recent interval are reported. ([#501](https://github.com/KindlingProject/kindling/pull/501))
 - Add a config to cgoreceiver for suppressing events according to processes' comm ([#495](https://github.com/KindlingProject/kindling/pull/495))
 - Add bind support to get the listening ip and port of a server. ([#493](https://github.com/KindlingProject/kindling/pull/493))
 - Add an option `enable_fetch_replicaset` to control whether to fetch ReplicaSet metadata. The default value is false which aims to release pressure on Kubernetes API server. ([#492](https://github.com/KindlingProject/kindling/pull/492))

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -199,6 +199,11 @@ exporters:
     custom_labels:
     prometheus:
       port: :9500
+      # with_memory sets the memory behavior of the exporter. If this is
+      # true, the exporter will report metric instruments and label sets
+      # that were previously reported but not updated in the most recent
+      # interval.
+      with_memory: false
     otlp:
       collect_period: 15s
       # Note: DO NOT add the prefix "http://"

--- a/collector/pkg/component/consumer/exporter/otelexporter/config.go
+++ b/collector/pkg/component/consumer/exporter/otelexporter/config.go
@@ -15,7 +15,8 @@ type Config struct {
 }
 
 type PrometheusConfig struct {
-	Port string `mapstructure:"port,omitempty"`
+	Port       string `mapstructure:"port,omitempty"`
+	WithMemory bool   `mapstructure:"with_memory,omitempty"`
 }
 
 type OtlpGrpcConfig struct {

--- a/collector/pkg/component/consumer/exporter/otelexporter/otelexporter.go
+++ b/collector/pkg/component/consumer/exporter/otelexporter/otelexporter.go
@@ -115,6 +115,7 @@ func NewExporter(config interface{}, telemetry *component.TelemetryTools) export
 					histogram.WithExplicitBoundaries(exponentialInt64NanosecondsBoundaries),
 				),
 				aggregation.CumulativeTemporalitySelector(),
+				otelprocessor.WithMemory(cfg.PromCfg.WithMemory),
 			),
 			controller.WithResource(rs),
 		)

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -199,6 +199,11 @@ exporters:
     custom_labels:
     prometheus:
       port: :9500
+      # with_memory sets the memory behavior of the exporter. If this is
+      # true, the exporter will report metric instruments and label sets
+      # that were previously reported but not updated in the most recent
+      # interval.
+      with_memory: false
     otlp:
       collect_period: 15s
       # Note: DO NOT add the prefix "http://"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add an option `WithMemory` to OpenTelemetry's Prometheus exporter.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
#496 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Opentelemetry-go offers an option called `WithMemory` that allows users to control whether metrics that haven't been updated in the most recent interval are reported. Users may want to set it to `true` to scrape metrics continuously. So this option is exposed in the configuration file. 

Since reporting all metrics every time can lead to performance issues if there are a large number of metrics, the default value of `false` has been retained to maintain the current behavior.
