### PR TITLE
The probe will gracefully exit and close the async-profiler.

### DIFF
--- a/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
+++ b/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
@@ -114,6 +114,7 @@ func (r *CgoReceiver) consumeEvents() {
 
 func (r *CgoReceiver) Shutdown() error {
 	// TODO stop the C routine
+	C.stopProfile()
 	close(r.stopCh)
 	r.shutdownWG.Wait()
 	return nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add stopProfile() method when shudown
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The probe will gracefully exit and close the async-profiler.
## How Has This Been Tested?
<img width="716" alt="9da37e1bbd6a56a1fc1dc28783878859" src="https://user-images.githubusercontent.com/48346142/234775958-476f8856-6647-44cb-bb41-6884fd918b75.png">

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->