### PR TITLE
fix the panic: send on closed channel

### DIFF
--- a/collector/pkg/component/analyzer/cpuanalyzer/delete_tid.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/delete_tid.go
@@ -40,6 +40,8 @@ func (dq *tidDeleteQueue) Pop() {
 func (ca *CpuAnalyzer) TidDelete(interval time.Duration, expiredDuration time.Duration) {
 	for {
 		select {
+		case <-ca.stopProfileChan:
+			return
 		case <-time.After(interval):
 			now := time.Now()
 			func() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix the panic: send on closed channel.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
![image](https://github.com/KindlingProject/kindling/assets/46807570/b3f312f4-c50b-4ed3-b086-aa72bb5e751e)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There are two solutions available:
- Close the channel on the sender side. We have to add some checks to ensure everything functions correctly.
- Do not close the channel and ensure it can be garbage collected when profiling is disabled, without any memory leaks or blocked goroutines. This can be achieved by listening to a "stop" channel and removing references to the old channel when disabling the profiling.

I have chosen the second solution to fix this bug. I renew the relevant channels and maps during the start and stop phases of profiling to ensure they are empty. Since starting and stopping profiling are both infrequent operations, the overhead on performance will be minimal.