### PR TITLE
Refactor the data format of on/off CPU events to array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ## Unreleased
 ### New features
 - Display scheduler run queue latency on Trace-Profiling chart. To learn more about the concept of 'Run Queue Latency', refer to [this blog post](https://www.brendangregg.com/blog/2016-10-08/linux-bcc-runqlat.html). You can also find a use case for this feature in [this blog post](http://kindling.harmonycloud.cn/blogs/use-cases/optimize-cpu/). ([#494](https://github.com/KindlingProject/kindling/pull/494))
+### Enhancements
+- ⚠️Breaking change: Refactor the data format of on/off CPU events from "string" to "array". Note that the old data format cannot be parsed using the new version of the front-end.([#512](https://github.com/KindlingProject/kindling/pull/512) [#520](https://github.com/KindlingProject/kindling/pull/520))
 ### Bug fixes
 - Fix panic: send on closed channel. ([#519](https://github.com/KindlingProject/kindling/pull/519))
 - Fix the bug that the event detail panel doesn't hide when switching profiles.（[#513](https://github.com/KindlingProject/kindling/pull/513)）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New features
 - Display scheduler run queue latency on Trace-Profiling chart. To learn more about the concept of 'Run Queue Latency', refer to [this blog post](https://www.brendangregg.com/blog/2016-10-08/linux-bcc-runqlat.html). You can also find a use case for this feature in [this blog post](http://kindling.harmonycloud.cn/blogs/use-cases/optimize-cpu/). ([#494](https://github.com/KindlingProject/kindling/pull/494))
 ### Bug fixes
+- Fix panic: send on closed channel. ([#519](https://github.com/KindlingProject/kindling/pull/519))
 - Fix the bug that the event detail panel doesn't hide when switching profiles.（[#513](https://github.com/KindlingProject/kindling/pull/513)）
 - Fix span data deduplication issue.（[#511](https://github.com/KindlingProject/kindling/pull/511)）
 

--- a/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
@@ -1,6 +1,8 @@
 package cpuanalyzer
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
 	"strconv"
 	"sync"
@@ -207,12 +209,27 @@ func (ca *CpuAnalyzer) ConsumeCpuEvent(event *model.KindlingEvent) {
 			ev.StartTime = userAttributes.GetUintValue()
 		case event.UserAttributes[i].GetKey() == "end_time":
 			ev.EndTime = userAttributes.GetUintValue()
-		case event.UserAttributes[i].GetKey() == "type_specs":
-			ev.TypeSpecs = string(userAttributes.GetValue())
+		case event.UserAttributes[i].GetKey() == "time_specs":
+			val := userAttributes.GetValue()
+			ev.TypeSpecs = make([]uint64, len(val)/8)
+			err := binary.Read(bytes.NewBuffer(val), binary.LittleEndian, ev.TypeSpecs)
+			if err != nil {
+				ca.telemetry.Logger.Error("Failed to read time_specs")
+			}
 		case event.UserAttributes[i].GetKey() == "runq_latency":
-			ev.RunqLatency = string(userAttributes.GetValue())
+			val := userAttributes.GetValue()
+			ev.RunqLatency = make([]uint64, len(val)/8)
+			err := binary.Read(bytes.NewBuffer(val), binary.LittleEndian, ev.RunqLatency)
+			if err != nil {
+				ca.telemetry.Logger.Error("Failed to read runq_latency")
+			}
 		case event.UserAttributes[i].GetKey() == "time_type":
-			ev.TimeType = string(userAttributes.GetValue())
+			val := userAttributes.GetValue()
+			ev.TimeType = make([]CPUType, len(val))
+			err := binary.Read(bytes.NewBuffer(val), binary.LittleEndian, ev.TimeType)
+			if err != nil {
+				ca.telemetry.Logger.Error("Failed to read time_type")
+			}
 		case event.UserAttributes[i].GetKey() == "on_info":
 			ev.OnInfo = string(userAttributes.GetValue())
 		case event.UserAttributes[i].GetKey() == "off_info":

--- a/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/cpu_analyzer.go
@@ -70,7 +70,9 @@ func (ca *CpuAnalyzer) Start() error {
 }
 
 func (ca *CpuAnalyzer) Shutdown() error {
-	_ = ca.StopProfile()
+	if enableProfile {
+		_ = ca.StopProfile()
+	}
 	return nil
 }
 

--- a/collector/pkg/component/analyzer/cpuanalyzer/model_test.go
+++ b/collector/pkg/component/analyzer/cpuanalyzer/model_test.go
@@ -18,3 +18,23 @@ func TestMarshalSomeFields(t *testing.T) {
 	}
 	t.Log(string(cpuEvents))
 }
+
+func TestCPUType_MarshalJSON(t *testing.T) {
+	ct := CPUType_FILE
+	data, err := ct.MarshalJSON()
+	if err != nil {
+		t.Failed()
+	}
+	t.Log(string(data))
+}
+
+func TestCPUType_UnmarshalJSON(t *testing.T) {
+	data := []byte{49}
+
+	var ct CPUType
+	err := ct.UnmarshalJSON(data)
+	if err != nil {
+		t.Failed()
+	}
+	t.Log(ct)
+}

--- a/probe/src/converter/cpu_converter.cpp
+++ b/probe/src/converter/cpu_converter.cpp
@@ -53,42 +53,22 @@ int cpu_converter::add_cpu_data(kindling_event_t_for_go* p_kindling_event, sinsp
   uint64_t* runq_latency =
       reinterpret_cast<uint64_t*>(sevt->get_param_value_raw("runq_latency")->m_val);
   uint8_t* time_type = reinterpret_cast<uint8_t*>(sevt->get_param_value_raw("time_type")->m_val);
-  cpu_data c_data;
+
   vector<pair<uint64_t, uint64_t>> on_time, off_time;
   vector<uint8_t> off_type;
   uint64_t start = start_time;
 
   for (int i = 0; i < cnt; i++) {
     if (time_type[i] == 0) {
-      c_data.on_total_time += time_specs[i];
       on_time.emplace_back(start, start + time_specs[i]);
     } else {
-      c_data.off_total_time += time_specs[i];
-      c_data.runq_latency += (to_string(runq_latency[i / 2]) + ",");
       off_time.emplace_back(start, start + time_specs[i]);
-
       off_type.emplace_back(time_type[i]);
     }
     start = start + time_specs[i];
-    c_data.time_specs += (to_string(time_specs[i]) + ",");
-    c_data.time_type += (to_string(time_type[i]) + ",");
   }
 
   uint16_t userAttNumber = 0;
-  // on_total_time
-  strcpy(p_kindling_event->userAttributes[userAttNumber].key, "on_total_time");
-  memcpy(p_kindling_event->userAttributes[userAttNumber].value, &c_data.on_total_time, 8);
-  p_kindling_event->userAttributes[userAttNumber].valueType = UINT64;
-  p_kindling_event->userAttributes[userAttNumber].len = 8;
-  userAttNumber++;
-
-  // off_total_time
-  strcpy(p_kindling_event->userAttributes[userAttNumber].key, "off_total_time");
-  memcpy(p_kindling_event->userAttributes[userAttNumber].value, &c_data.off_total_time, 8);
-  p_kindling_event->userAttributes[userAttNumber].valueType = UINT64;
-  p_kindling_event->userAttributes[userAttNumber].len = 8;
-  userAttNumber++;
-
   // start_time
   strcpy(p_kindling_event->userAttributes[userAttNumber].key, "start_time");
   memcpy(p_kindling_event->userAttributes[userAttNumber].value, &start_time, 8);
@@ -104,27 +84,24 @@ int cpu_converter::add_cpu_data(kindling_event_t_for_go* p_kindling_event, sinsp
   userAttNumber++;
 
   // time_specs
-  strcpy(p_kindling_event->userAttributes[userAttNumber].key, "type_specs");
-  memcpy(p_kindling_event->userAttributes[userAttNumber].value, c_data.time_specs.data(),
-         c_data.time_specs.length());
-  p_kindling_event->userAttributes[userAttNumber].valueType = CHARBUF;
-  p_kindling_event->userAttributes[userAttNumber].len = c_data.time_specs.length();
+  strcpy(p_kindling_event->userAttributes[userAttNumber].key, "time_specs");
+  memcpy(p_kindling_event->userAttributes[userAttNumber].value, time_specs, 8 * cnt);
+  p_kindling_event->userAttributes[userAttNumber].valueType = BYTEBUF;
+  p_kindling_event->userAttributes[userAttNumber].len = 8 * cnt;
   userAttNumber++;
 
   // runq_latency
   strcpy(p_kindling_event->userAttributes[userAttNumber].key, "runq_latency");
-  memcpy(p_kindling_event->userAttributes[userAttNumber].value, c_data.runq_latency.data(),
-         c_data.runq_latency.length());
-  p_kindling_event->userAttributes[userAttNumber].valueType = CHARBUF;
-  p_kindling_event->userAttributes[userAttNumber].len = c_data.runq_latency.length();
+  memcpy(p_kindling_event->userAttributes[userAttNumber].value, runq_latency, cnt / 2 * 8);
+  p_kindling_event->userAttributes[userAttNumber].valueType = BYTEBUF;
+  p_kindling_event->userAttributes[userAttNumber].len =  cnt / 2 * 8;
   userAttNumber++;
 
   // time_type
   strcpy(p_kindling_event->userAttributes[userAttNumber].key, "time_type");
-  memcpy(p_kindling_event->userAttributes[userAttNumber].value, c_data.time_type.data(),
-         c_data.time_type.length());
-  p_kindling_event->userAttributes[userAttNumber].valueType = CHARBUF;
-  p_kindling_event->userAttributes[userAttNumber].len = c_data.time_type.length();
+  memcpy(p_kindling_event->userAttributes[userAttNumber].value, time_type, cnt);
+  p_kindling_event->userAttributes[userAttNumber].valueType = BYTEBUF;
+  p_kindling_event->userAttributes[userAttNumber].len = cnt;
   userAttNumber++;
 
   // on_stack

--- a/probe/src/converter/cpu_converter.h
+++ b/probe/src/converter/cpu_converter.h
@@ -5,18 +5,6 @@
 #include "cgo/kindling.h"
 #include "sinsp.h"
 
-class cpu_data {
- public:
-  uint64_t start_time;
-  uint64_t end_time;
-  uint64_t on_total_time;
-  uint64_t off_total_time;
-  string time_specs;
-  string runq_latency;
-  string time_type;
-  uint32_t tid;
-};
-
 class cpu_converter {
  public:
   cpu_converter(sinsp* inspector);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Refactor the data format of on/off CPU events from "string" to "array".

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
This change on the agent is accompanied by PR #512, which includes corresponding changes on the front end.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At present, the on/off CPU events are stored as a "string" type in the "cpuEvent" field, despite being inherently arrays. This PR aims to refactor the data format to use the "array" type instead, to simplify the processing code. However, it's crucial to note that this is a breaking change, meaning that the new data cannot be parsed using previous versions of the front-end, and conversely, the old data format cannot be parsed using the new version of the front-end.