### PR TITLE
Fix probe merge

### DIFF
--- a/collector/docker/kindling-probe-loader
+++ b/collector/docker/kindling-probe-loader
@@ -102,7 +102,11 @@ PROBE_NAME="kindling-falcolib-probe"
 MAX_RMMOD_WAIT=60
 
 tar -zxvf /app/kindling-falcolib-probe.tar.gz -C /opt
-mv /opt/kindling-falcolib-probe /opt/.kindling
+if [ -d /opt/.kindling ]; then
+  mv -f /opt/kindling-falcolib-probe/* /opt/.kindling/
+else
+  mv /opt/kindling-falcolib-probe/ /opt/.kindling/
+fi
 
 if [ -d /opt/kindling-extra-probe ]; then
 	/bin/cp -rf /opt/kindling-extra-probe/* /opt/.kindling/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
当kindling发生重启时，启动脚本不是幂等的

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->