### PR TITLE
Enhance MySql CommandLine Case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New features
 - Display scheduler run queue latency on Trace-Profiling chart. To learn more about the concept of 'Run Queue Latency', refer to [this blog post](https://www.brendangregg.com/blog/2016-10-08/linux-bcc-runqlat.html). You can also find a use case for this feature in [this blog post](http://kindling.harmonycloud.cn/blogs/use-cases/optimize-cpu/). ([#494](https://github.com/KindlingProject/kindling/pull/494))
 ### Enhancements
+- Mysql CommandLine Case: Ignore quit command and got sql with CLIENT_QUERY_ATTRIBUTES([#523](https://github.com/KindlingProject/kindling/pull/523))
 - ⚠️Breaking change: Refactor the data format of on/off CPU events from "string" to "array". Note that the old data format cannot be parsed using the new version of the front-end.([#512](https://github.com/KindlingProject/kindling/pull/512) [#520](https://github.com/KindlingProject/kindling/pull/520))
 ### Bug fixes
 - Fix panic: send on closed channel. ([#519](https://github.com/KindlingProject/kindling/pull/519))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### New features
 - Display scheduler run queue latency on Trace-Profiling chart. To learn more about the concept of 'Run Queue Latency', refer to [this blog post](https://www.brendangregg.com/blog/2016-10-08/linux-bcc-runqlat.html). You can also find a use case for this feature in [this blog post](http://kindling.harmonycloud.cn/blogs/use-cases/optimize-cpu/). ([#494](https://github.com/KindlingProject/kindling/pull/494))
 ### Enhancements
-- Mysql CommandLine Case: Ignore quit command and got sql with CLIENT_QUERY_ATTRIBUTES([#523](https://github.com/KindlingProject/kindling/pull/523))
+- MySQL CommandLine Case: Ignore quit command and get sql with CLIENT_QUERY_ATTRIBUTES([#523](https://github.com/KindlingProject/kindling/pull/523))
 - ⚠️Breaking change: Refactor the data format of on/off CPU events from "string" to "array". Note that the old data format cannot be parsed using the new version of the front-end.([#512](https://github.com/KindlingProject/kindling/pull/512) [#520](https://github.com/KindlingProject/kindling/pull/520))
 ### Bug fixes
 - Fix panic: send on closed channel. ([#519](https://github.com/KindlingProject/kindling/pull/519))

--- a/collector/pkg/component/analyzer/network/network_analyzer.go
+++ b/collector/pkg/component/analyzer/network/network_analyzer.go
@@ -449,6 +449,9 @@ func (na *NetworkAnalyzer) parseProtocol(mps *messagePairs, parser *protocol.Pro
 	}
 
 	if mps.responses == nil {
+		if requestMsg.GetAttributes().GetBoolValue(constlabels.Oneway) {
+			return []*model.DataGroup{}
+		}
 		return na.getRecords(mps, parser.GetProtocol(), requestMsg.GetAttributes())
 	}
 

--- a/collector/pkg/component/analyzer/network/network_analyzer_test.go
+++ b/collector/pkg/component/analyzer/network/network_analyzer_test.go
@@ -33,7 +33,9 @@ func TestMySqlProtocol(t *testing.T) {
 	testProtocol(t, "mysql/server-event.yml",
 		"mysql/server-trace-commit.yml",
 		"mysql/server-trace-query-split.yml",
-		"mysql/server-trace-query.yml")
+		"mysql/server-trace-query.yml",
+		"mysql/server-trace-oneway.yml",
+	)
 }
 
 func TestRedisProtocol(t *testing.T) {

--- a/collector/pkg/component/analyzer/network/network_analyzer_test.go
+++ b/collector/pkg/component/analyzer/network/network_analyzer_test.go
@@ -35,6 +35,7 @@ func TestMySqlProtocol(t *testing.T) {
 		"mysql/server-trace-query-split.yml",
 		"mysql/server-trace-query.yml",
 		"mysql/server-trace-oneway.yml",
+		"mysql/server-trace-query-cmd.yml",
 	)
 }
 

--- a/collector/pkg/component/analyzer/network/protocol/mysql/mysql_parser.go
+++ b/collector/pkg/component/analyzer/network/protocol/mysql/mysql_parser.go
@@ -5,14 +5,15 @@ import (
 )
 
 /*
-      Request                                         Response
-       /            \                                            /     |    \
-prepare   query                                err   ok  eof
+		    Request                                       Response
+		/     |       \                                 /     |    \
+	 prepare query   quit                              err   ok    eof
 */
 func NewMysqlParser() *protocol.ProtocolParser {
 	requestParser := protocol.CreatePkgParser(fastfailMysqlRequest(), parseMysqlRequest())
 	requestParser.Add(fastfailMysqlPrepare(), parseMysqlPrepare())
 	requestParser.Add(fastfailMysqlQuery(), parseMysqlQuery())
+	requestParser.Add(fastfailMysqlQuit(), parseMysqlQuit())
 
 	responseParser := protocol.CreatePkgParser(fastfailMysqlResponse(), parseMysqlResponse())
 	responseParser.Add(fastfailMysqlErr(), parseMysqlErr())

--- a/collector/pkg/component/analyzer/network/protocol/mysql/mysql_request.go
+++ b/collector/pkg/component/analyzer/network/protocol/mysql/mysql_request.go
@@ -51,6 +51,12 @@ func parseMysqlPrepare() protocol.ParsePkgFn {
 /*
 ===== PayLoad =====
 1              COM_QUERY<03>
+CLIENT_QUERY_ATTRIBUTES
+
+	1            Number of parameters
+	1            Number of parameter sets. Currently always 1
+	...
+
 string[EOF]    the query the server shall execute
 */
 func fastfailMysqlQuery() protocol.FastFailFn {
@@ -62,6 +68,11 @@ func fastfailMysqlQuery() protocol.FastFailFn {
 func parseMysqlQuery() protocol.ParsePkgFn {
 	return func(message *protocol.PayloadMessage) (bool, bool) {
 		sql := string(message.Data[5:])
+		if len(sql) > 2 && sql[0] == 0x00 && sql[1] == 0x01 {
+			// Only Fix Zero params Case.
+			// TODO Fix One more params case.
+			sql = sql[2:]
+		}
 		if !isSql(sql) {
 			return false, true
 		}

--- a/collector/pkg/component/analyzer/network/protocol/mysql/mysql_request.go
+++ b/collector/pkg/component/analyzer/network/protocol/mysql/mysql_request.go
@@ -72,6 +72,23 @@ func parseMysqlQuery() protocol.ParsePkgFn {
 	}
 }
 
+/*
+===== PayLoad =====
+1              COM_QUIT<01>
+*/
+func fastfailMysqlQuit() protocol.FastFailFn {
+	return func(message *protocol.PayloadMessage) bool {
+		return message.Data[4] != 1
+	}
+}
+
+func parseMysqlQuit() protocol.ParsePkgFn {
+	return func(message *protocol.PayloadMessage) (bool, bool) {
+		message.AddBoolAttribute(constlabels.Oneway, true)
+		return true, true
+	}
+}
+
 var sqlPrefixs = []string{
 	"select",
 	"insert",

--- a/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-oneway.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-oneway.yml
@@ -1,0 +1,14 @@
+trace:
+  key: oneway
+  requests:
+    -
+      name: "recvfrom"
+      timestamp: 100000000
+      user_attributes:
+        latency: 2000
+        res: 24
+        data:
+          - "hex|14000000"
+          - "hex|01"
+  expects:
+    # No Result, Ignore it.

--- a/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-query-cmd.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-query-cmd.yml
@@ -1,5 +1,5 @@
 trace:
-  key: query
+  key: query-cmd
   requests:
     -
       name: "recvfrom"
@@ -9,7 +9,7 @@ trace:
         res: 24
         data:
           - "hex|14000000"
-          - "03|SELECT * FROM dummy"
+          - "030001|SELECT * FROM dummy"
   responses:
     -
       name: "sendto"
@@ -58,7 +58,7 @@ trace:
         protocol: "mysql"
         content_key: "select dummy *"
         sql: "SELECT * FROM dummy"
-        request_payload: ".....SELECT * FROM dummy"
+        request_payload: ".......SELECT * FROM dummy"
         response_payload: ".....9....def.container-monitor.dummy.dummy.name.name.-...........;....def.conta"
         is_error: false
         error_type: 0

--- a/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-query.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/mysql/server-trace-query.yml
@@ -9,7 +9,7 @@ trace:
         res: 24
         data:
           - "hex|14000000"
-          - "03|SELECT * FROM dummy"
+          - "030001|SELECT * FROM dummy"
   responses:
     -
       name: "sendto"
@@ -58,7 +58,7 @@ trace:
         protocol: "mysql"
         content_key: "select dummy *"
         sql: "SELECT * FROM dummy"
-        request_payload: ".....SELECT * FROM dummy"
+        request_payload: ".......SELECT * FROM dummy"
         response_payload: ".....9....def.container-monitor.dummy.dummy.name.name.-...........;....def.conta"
         is_error: false
         error_type: 0

--- a/collector/pkg/model/constlabels/protocols.go
+++ b/collector/pkg/model/constlabels/protocols.go
@@ -17,6 +17,8 @@ const (
 	DnsRcode  = "dns_rcode"
 	DnsIp     = "dns_ip"
 
+	Oneway = "one_way"
+
 	Sql        = "sql"
 	SqlErrCode = "sql_error_code"
 	SqlErrMsg  = "sql_error_msg"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Quit is one-way request which will be recognized as no response data, therefore we ignore the quit command datas.
Fix MySQL get no sql with ComandLine.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Refer to [MySQL_COM_QUERY](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_query.html), commandLine case will add CLIENT_QUERY_ATTRIBUTES info.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
--- PASS: TestMySqlProtocol
    --- PASS: TestMySqlProtocol/commit
    --- PASS: TestMySqlProtocol/query-split 
    --- PASS: TestMySqlProtocol/query
    --- PASS: TestMySqlProtocol/oneway
    --- PASS: TestMySqlProtocol/query-cmd