### PR TITLE
Batch event retrieval in cgo for performance enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Expand the histogram bucket of otelexpoerter (Add 1500ms). ([#563](https://github.com/KindlingProject/kindling/pull/563))
 - Set default values of `store_external_src_ip` and `StoreExternalSrcIP` to false to reduce occurrences of unexpected src IP data. ([#562](https://github.com/KindlingProject/kindling/pull/562))
 - Optimized the `networkanalyzer` component of the probe analyzer by utilizing Go's goroutines, enabling concurrent execution. ([#558](https://github.com/KindlingProject/kindling/pull/558))
+- Improved event processing efficiency with batch event retrieval in cgo. ([#560](https://github.com/KindlingProject/kindling/pull/560))
 
 ### Bug fixes
 - Enhance dns with udp which is out of order.([#565](https://github.com/KindlingProject/kindling/pull/565))

--- a/collector/pkg/component/receiver/cgoreceiver/cgo_func.h
+++ b/collector/pkg/component/receiver/cgoreceiver/cgo_func.h
@@ -9,8 +9,7 @@
 extern "C" {
 #endif
 int runForGo();
-int getKindlingEvent(void **kindlingEvent);
-int getKindlingEvents(void** kindlingEvent);
+int getEventsByInterval(int interval, void** kindlingEvent, void* count);
 void suppressEventsCommForGo(char *comm);
 void subEventForGo(char* eventName, char* category, void *params);
 int startProfile();

--- a/collector/pkg/component/receiver/cgoreceiver/cgo_func.h
+++ b/collector/pkg/component/receiver/cgoreceiver/cgo_func.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 int runForGo();
 int getKindlingEvent(void **kindlingEvent);
+int getKindlingEvents(void** kindlingEvent);
 void suppressEventsCommForGo(char *comm);
 void subEventForGo(char* eventName, char* category, void *params);
 int startProfile();

--- a/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
+++ b/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
@@ -82,16 +82,18 @@ func (r *CgoReceiver) Start() error {
 }
 
 func (r *CgoReceiver) startGetEvents() {
-    var pKindlingEvents [10]unsafe.Pointer
+	var count = 0
+    var pKindlingEvents [1000]unsafe.Pointer
     r.shutdownWG.Add(1)
+
     for {
         select {
         case <-r.stopCh:
             r.shutdownWG.Done()
             return
         default:
-            count := int(C.getKindlingEvents(&pKindlingEvents[0]))
-            for i := 0; i < count; i++ {
+            evt_count := int(C.getEventsByInterval(C.int(100000000), &pKindlingEvents[0], (unsafe.Pointer)(&count)))
+            for i := 0; i < evt_count; i++ {
                 event := convertEvent((*CKindlingEventForGo)(pKindlingEvents[i]))
                 r.eventChannel <- event
                 r.stats.add(event.Name, 1)

--- a/probe/src/cgo/cgo_func.cpp
+++ b/probe/src/cgo/cgo_func.cpp
@@ -9,6 +9,7 @@
 int runForGo() { return init_probe(); }
 
 int getKindlingEvent(void** kindlingEvent) { return getEvent(kindlingEvent); }
+int getKindlingEvents(void** kindlingEvents) { return get_events(kindlingEvents); }
 
 int startProfile() { return start_profile(); }
 int stopProfile() { return stop_profile(); }

--- a/probe/src/cgo/cgo_func.cpp
+++ b/probe/src/cgo/cgo_func.cpp
@@ -8,8 +8,9 @@
 
 int runForGo() { return init_probe(); }
 
-int getKindlingEvent(void** kindlingEvent) { return getEvent(kindlingEvent); }
-int getKindlingEvents(void** kindlingEvents) { return get_events(kindlingEvents); }
+int getEventsByInterval(int interval, void** kindlingEvent, void* count) { 
+    return get_events_by_interval((uint64_t)interval, kindlingEvent, count); 
+}
 
 int startProfile() { return start_profile(); }
 int stopProfile() { return stop_profile(); }

--- a/probe/src/cgo/cgo_func.h
+++ b/probe/src/cgo/cgo_func.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 int runForGo();
 int getKindlingEvent(void** kindlingEvent);
+int getKindlingEvents(void** kindlingEvent);
 void suppressEventsCommForGo(char *comm);
 void subEventForGo(char* eventName, char* category, void* params);
 int startProfile();

--- a/probe/src/cgo/cgo_func.h
+++ b/probe/src/cgo/cgo_func.h
@@ -9,8 +9,7 @@
 extern "C" {
 #endif
 int runForGo();
-int getKindlingEvent(void** kindlingEvent);
-int getKindlingEvents(void** kindlingEvent);
+int getEventsByInterval(int interval, void** kindlingEvent, void* count);
 void suppressEventsCommForGo(char *comm);
 void subEventForGo(char* eventName, char* category, void* params);
 int startProfile();

--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -89,6 +89,18 @@ void sub_event(char* eventName, char* category, event_params_for_subscribe param
   }
 }
 
+#define MAX_EVENTS 10  
+int get_events(void** kindlingEvents) {
+    int count = 0;
+    for (int i = 0; i < MAX_EVENTS; i++) {
+        if (getEvent(&kindlingEvents[i]) != 1) {
+            break;
+        }
+        count++;
+    }
+    return count;  
+}
+
 void suppress_events_comm(string comm) {
   printCurrentTime();
   cout << "suppress_events for process " << comm << endl;

--- a/probe/src/cgo/kindling.h
+++ b/probe/src/cgo/kindling.h
@@ -26,6 +26,8 @@ void exipre_window_cache();
 
 int getEvent(void** kindlingEvent);
 
+int get_events(void** kindlingEvents);
+
 uint16_t get_kindling_category(sinsp_evt* sEvt);
 
 void init_sub_label();

--- a/probe/src/cgo/kindling.h
+++ b/probe/src/cgo/kindling.h
@@ -24,9 +24,9 @@ void stop_perf();
 
 void exipre_window_cache();
 
-int getEvent(void** kindlingEvent);
+int getEvent(uint64_t interval, void** kindlingEvent, int* event_count);
 
-int get_events(void** kindlingEvents);
+int get_events_by_interval(uint64_t interval, void** kindlingEvent, void* count);
 
 uint16_t get_kindling_category(sinsp_evt* sEvt);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Introduced a new function in cgo to retrieve multiple events in a single call, aiming to improve the efficiency of event processing. Instead of fetching one event at a time, the system can now fetch up to a predefined number of events, reducing the overhead of function calls and potentially improving the overall throughput of the event handling mechanism.

Changes made:

Added a new function getKindlingEvents in cgo_func.cpp which calls the get_events function in kindling.cpp.
The get_events function in kindling.cpp is designed to fetch multiple events up to a defined maximum (MAX_EVENTS).
Modified the startGetEvent function in Go to handle the batch of events returned by the new getKindlingEvents function.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The compiled image runs normally.