### PR TITLE
Fix potential nil pointer in podMap's delete method

### DIFF
--- a/collector/pkg/metadata/kubernetes/pod_watch.go
+++ b/collector/pkg/metadata/kubernetes/pod_watch.go
@@ -95,12 +95,16 @@ func (m *podMap) delete(namespace string, name string) (*K8sPodInfo, bool) {
 	m.mutex.Lock()
 	podInfoMap, ok := m.Info[namespace]
 	var podInfo *K8sPodInfo
-	if ok {
-		podInfo = podInfoMap[name]
-		delete(podInfoMap, name)
+	if !ok {
+		return nil, false
 	}
+	podInfo, ok = podInfoMap[name]
+	if !ok {
+		return nil, false
+	}
+	delete(podInfoMap, name)
 	m.mutex.Unlock()
-	return podInfo, ok
+	return podInfo, true
 }
 
 func (m *workloadMap) add(info *WorkloadInfo) {

--- a/collector/pkg/metadata/kubernetes/pod_watch_test.go
+++ b/collector/pkg/metadata/kubernetes/pod_watch_test.go
@@ -358,3 +358,20 @@ func Test_extractDeploymentName(t *testing.T) {
 		})
 	}
 }
+
+func TestDelete(t *testing.T) {
+	pm := newPodMap()
+
+	info := &K8sPodInfo{
+		Namespace: "test-namespace",
+		PodName:   "test-podname",
+	}
+	pm.add(info)
+
+	deletedPodInfo, ok := pm.delete("test-namespace", "test-podname")
+	assert.True(t, ok, "expected pod to be deleted successfully")
+	assert.Equal(t, info, deletedPodInfo, "deleted pod info should match the added one")
+
+	_, ok = pm.delete("test-namespace", "nonexistent-pod")
+	assert.False(t, ok, "expected pod deletion to fail for nonexistent pod")
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed a panic that occurred due to a nil pointer dereference in pod_delete.go.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
Issue #552: panic due to pod_delete.go:67

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A unit test was written and passed successfully.