### PR TITLE
fix receivers config unit tests

### DIFF
--- a/collector/internal/application/testdata/kindling-collector-config.yaml
+++ b/collector/internal/application/testdata/kindling-collector-config.yaml
@@ -33,3 +33,41 @@ processors:
     # is used to control pods in the third-party CRD except for Deployment.
     enable_fetch_replicaset: true
   nodemetricprocessor:
+receivers:
+  cgoreceiver:
+    subscribe:
+      - name: syscall_exit-writev
+        category: net
+      - name: syscall_exit-readv
+        category: net
+      - name: syscall_exit-write
+        category: net
+      - name: syscall_exit-read
+        category: net
+      - name: syscall_exit-sendto
+        category: net
+      - name: syscall_exit-recvfrom
+        category: net
+      - name: syscall_exit-sendmsg
+        category: net
+      - name: syscall_exit-recvmsg
+        category: net
+      - name: syscall_exit-sendmmsg
+        category: net
+      - name: kprobe-tcp_close
+      - name: kprobe-tcp_rcv_established
+      - name: kprobe-tcp_drop
+      - name: kprobe-tcp_retransmit_skb
+      - name: syscall_exit-connect
+      - name: kretprobe-tcp_connect
+      - name: kprobe-tcp_set_state
+      - name: tracepoint-procexit
+    process_filter:
+      # the length of a comm should be no more than 16
+      comms:
+        - "kindling-collec"
+        - "containerd"
+        - "dockerd"
+        - "containerd-shim"
+        - "filebeat"
+        - "java"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When reading `kindling-collector-config.yaml` file, if there are no `receivers`, the default receivers configuration will not take effect and will be empty. If there are `receviers`, it can be read normally.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test the case where the profile receiver is empty.
### Expected results
If empty it will output the default configuration.
### Test results
Configuration found to be empty and not as expected。
![image](https://github.com/KindlingProject/kindling/assets/88039311/a0d19ff0-c7d1-4001-b570-8f387d0e629f)




