### PR TITLE
fix: check nil pointer in metadata provider and clean up unsafe Lock/Unlock ; add default Configuration for agent

### DIFF
--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -144,6 +144,19 @@ processors:
     # The default value is false. It should be enabled if the ReplicaSet
     # is used to control pods in the third-party CRD except for Deployment.
     enable_fetch_replicaset: false
+    # metadata_provider is an independent program used to collect k8sMetadata from API-server and sync with every agent
+    # whether this configuration is enabled or not does not affect the output format
+    # once enabled, agent will fetch metadata from metadata_provider instead of communicate with API-server 
+    # that can reduce the pressure on API-server and transmitting less data 
+    metadata_provider_config:
+      # confirm that metedata_provider is deployed before you enable the configuration
+      # deploy metedata_provider by `kubectl create -f deploy/metadata-provider/metadata-provider-deploy.yml`
+      enable: false
+      # set `enable_trace` as true only if you need to debug the metadata from metadata_provider
+      # each k8sMetadata fetched from metadata_provider will be printed into console
+      enable_trace: false
+      # check service endpoint by `kubectl get endpoints metadata-provider  -n kindling``
+      endpoint: http://metadata-provider.kindling:9504
   aggregateprocessor:
     # Aggregation duration window size. The unit is second.
     ticker_interval: 5

--- a/collector/pkg/metadata/kubernetes/initk8s.go
+++ b/collector/pkg/metadata/kubernetes/initk8s.go
@@ -17,8 +17,6 @@ import (
 // AuthType describes the type of authentication to use for the K8s API
 type AuthType string
 
-var ReWatch bool
-
 const (
 	// AuthTypeNone means no auth is required
 	AuthTypeNone AuthType = "none"
@@ -110,16 +108,6 @@ func initWatcherFromMetadataProvider(k8sConfig config) error {
 	// Enable PodDeleteGrace
 	go podDeleteLoop(10*time.Second, k8sConfig.GraceDeletePeriod, stopCh)
 	go watchFromMPWithRetry(k8sConfig)
-
-	// rewatch from MP every 30 minute
-	ReWatch = false
-	go func() {
-		ticker := time.NewTicker(30 * time.Minute)
-		for range ticker.C {
-			clearK8sMap()
-			ReWatch = true
-		}
-	}()
 	return nil
 }
 
@@ -129,7 +117,6 @@ func watchFromMPWithRetry(k8sConfig config) {
 			if err := k8sConfig.listAndWatchFromProvider(SetupCache); err == nil {
 				i = 0
 				// receiver ReWatch signal , clear cache and rewatch from MP
-				// TODO logger
 				log.Printf("clear K8sCache and rewatch from MP")
 				continue
 			} else {

--- a/collector/pkg/metadata/kubernetes/initk8s.go
+++ b/collector/pkg/metadata/kubernetes/initk8s.go
@@ -210,21 +210,17 @@ func createRestConfig(apiConf APIConfig) (*rest.Config, error) {
 	return authConf, nil
 }
 
-func clearK8sMap() {
-	GlobalPodInfo = newPodMap()
-	GlobalNodeInfo = newNodeMap()
-	GlobalRsInfo = newReplicaSetMap()
-	GlobalServiceInfo = newServiceMap()
-}
-
+// Huge Lock, only used when setup and check the reentrant lock before you call
 func RLockMetadataCache() {
 	MetaDataCache.cMut.RLock()
 	MetaDataCache.pMut.RLock()
 	MetaDataCache.sMut.RLock()
 	MetaDataCache.HostPortInfo.mutex.RLock()
+	podDeleteQueueMut.Lock()
 }
 
 func RUnlockMetadataCache() {
+	podDeleteQueueMut.Unlock()
 	MetaDataCache.HostPortInfo.mutex.RUnlock()
 	MetaDataCache.sMut.RUnlock()
 	MetaDataCache.pMut.RUnlock()

--- a/collector/pkg/metadata/kubernetes/k8scache.go
+++ b/collector/pkg/metadata/kubernetes/k8scache.go
@@ -92,14 +92,14 @@ func New() *K8sMetaDataCache {
 
 func (c *K8sMetaDataCache) AddByContainerId(containerId string, resource *K8sContainerInfo) {
 	c.cMut.Lock()
+	defer c.cMut.Unlock()
 	c.ContainerIdInfo[containerId] = resource
-	c.cMut.Unlock()
 }
 
 func (c *K8sMetaDataCache) GetByContainerId(containerId string) (*K8sContainerInfo, bool) {
 	c.cMut.RLock()
+	defer c.cMut.RUnlock()
 	res, ok := c.ContainerIdInfo[containerId]
-	c.cMut.RUnlock()
 	if ok {
 		return res, ok
 	}
@@ -108,8 +108,8 @@ func (c *K8sMetaDataCache) GetByContainerId(containerId string) (*K8sContainerIn
 
 func (c *K8sMetaDataCache) GetPodByContainerId(containerId string) (*K8sPodInfo, bool) {
 	c.cMut.RLock()
+	defer c.cMut.RUnlock()
 	containerInfo, ok := c.ContainerIdInfo[containerId]
-	c.cMut.RUnlock()
 	if ok {
 		return containerInfo.RefPodInfo, ok
 	}
@@ -118,8 +118,8 @@ func (c *K8sMetaDataCache) GetPodByContainerId(containerId string) (*K8sPodInfo,
 
 func (c *K8sMetaDataCache) DeleteByContainerId(containerId string) {
 	c.cMut.Lock()
+	defer c.cMut.Unlock()
 	delete(c.ContainerIdInfo, containerId)
-	c.cMut.Unlock()
 }
 
 func (c *K8sMetaDataCache) AddContainerByIpPort(ip string, port uint32, resource *K8sContainerInfo) {
@@ -141,8 +141,8 @@ func (c *K8sMetaDataCache) AddContainerByIpPort(ip string, port uint32, resource
 
 func (c *K8sMetaDataCache) GetContainerByIpPort(ip string, port uint32) (*K8sContainerInfo, bool) {
 	c.pMut.RLock()
-	portContainerInfo, ok := c.IpContainerInfo[ip]
 	defer c.pMut.RUnlock()
+	portContainerInfo, ok := c.IpContainerInfo[ip]
 	if !ok {
 		return nil, false
 	}
@@ -178,8 +178,8 @@ func (c *K8sMetaDataCache) GetPodByIpPort(ip string, port uint32) (*K8sPodInfo, 
 
 func (c *K8sMetaDataCache) GetPodByIp(ip string) (*K8sPodInfo, bool) {
 	c.pMut.RLock()
-	portContainerInfo, ok := c.IpContainerInfo[ip]
 	defer c.pMut.RUnlock()
+	portContainerInfo, ok := c.IpContainerInfo[ip]
 	if !ok {
 		return nil, false
 	}

--- a/collector/pkg/metadata/kubernetes/pod_delete.go
+++ b/collector/pkg/metadata/kubernetes/pod_delete.go
@@ -64,7 +64,7 @@ func podDeleteLoop(interval time.Duration, gracePeriod time.Duration, stopCh cha
 func deletePodInfo(podInfo *deletedPodInfo) {
 	if podInfo.name != "" {
 		deletePodInfo, ok := GlobalPodInfo.delete(podInfo.namespace, podInfo.name)
-		if ok && deletePodInfo != nil && localWorkloadMap == nil {
+		if ok && deletePodInfo != nil && localWorkloadMap != nil {
 			localWorkloadMap.delete(deletePodInfo.Namespace, deletePodInfo.WorkloadName)
 		} else if ok && (deletePodInfo == nil || localWorkloadMap == nil) {
 			// don't know why this happen , print more message to console

--- a/collector/pkg/metadata/kubernetes/pod_delete.go
+++ b/collector/pkg/metadata/kubernetes/pod_delete.go
@@ -5,6 +5,7 @@
 package kubernetes
 
 import (
+	"log"
 	"sync"
 	"time"
 )
@@ -63,8 +64,16 @@ func podDeleteLoop(interval time.Duration, gracePeriod time.Duration, stopCh cha
 func deletePodInfo(podInfo *deletedPodInfo) {
 	if podInfo.name != "" {
 		deletePodInfo, ok := GlobalPodInfo.delete(podInfo.namespace, podInfo.name)
-		if ok {
+		if ok && deletePodInfo != nil && localWorkloadMap == nil {
 			localWorkloadMap.delete(deletePodInfo.Namespace, deletePodInfo.WorkloadName)
+		} else if ok && (deletePodInfo == nil || localWorkloadMap == nil) {
+			// don't know why this happen , print more message to console
+			log.Println("unexpected error happened when delete PodInfo from cache, which could lead to a segmentation violation")
+			log.Println("detailed info print below:")
+			log.Printf("\tdeletedPodInfo: %+v", podInfo)
+			if localWorkloadMap != nil {
+				log.Printf("\tlocalWorkloadMap: %+v", localWorkloadMap.Info)
+			}
 		}
 	}
 	if len(podInfo.containerIds) != 0 {

--- a/collector/pkg/metadata/kubernetes/pod_delete.go
+++ b/collector/pkg/metadata/kubernetes/pod_delete.go
@@ -71,8 +71,13 @@ func deletePodInfo(podInfo *deletedPodInfo) {
 			log.Println("unexpected error happened when delete PodInfo from cache, which could lead to a segmentation violation")
 			log.Println("detailed info print below:")
 			log.Printf("\tdeletedPodInfo: %+v", podInfo)
+			if deletePodInfo != nil {
+				log.Printf("\tmatchedPodInCache: %+v", *deletePodInfo)
+			}
 			if localWorkloadMap != nil {
-				log.Printf("\tlocalWorkloadMap: %+v", localWorkloadMap.Info)
+				log.Printf("\tlocalWorkloadMap is not nullptr")
+			} else {
+				log.Printf("\tlocalWorkloadMap is nullptr")
 			}
 		}
 	}

--- a/collector/pkg/metadata/kubernetes/pod_watch.go
+++ b/collector/pkg/metadata/kubernetes/pod_watch.go
@@ -86,17 +86,18 @@ func newWorkloadMap() *workloadMap {
 
 func (m *podMap) add(info *K8sPodInfo) {
 	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	podInfoMap, ok := m.Info[info.Namespace]
 	if !ok {
 		podInfoMap = make(map[string]*K8sPodInfo)
 	}
 	podInfoMap[info.PodName] = info
 	m.Info[info.Namespace] = podInfoMap
-	m.mutex.Unlock()
 }
 
 func (m *podMap) delete(namespace string, name string) (*K8sPodInfo, bool) {
 	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	podInfoMap, ok := m.Info[namespace]
 	var podInfo *K8sPodInfo
 	if !ok {
@@ -107,30 +108,27 @@ func (m *podMap) delete(namespace string, name string) (*K8sPodInfo, bool) {
 		return nil, false
 	}
 	delete(podInfoMap, name)
-	m.mutex.Unlock()
 	return podInfo, true
 }
 
 func (m *workloadMap) add(info *workloadInfo) {
 	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	workloadInfoMap, ok := m.Info[info.Namespace]
 	if !ok {
 		workloadInfoMap = make(map[string]*workloadInfo)
 	}
 	workloadInfoMap[info.WorkloadName] = info
 	m.Info[info.Namespace] = workloadInfoMap
-	m.mutex.Unlock()
-
 }
 
 func (m *workloadMap) delete(namespace string, name string) {
 	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	workloadInfoMap, ok := m.Info[namespace]
 	if ok {
 		delete(workloadInfoMap, name)
 	}
-	m.mutex.Unlock()
-
 }
 
 func (m *podMap) get(namespace string, name string) (*K8sPodInfo, bool) {

--- a/collector/pkg/metadata/kubernetes/replicaset_watch.go
+++ b/collector/pkg/metadata/kubernetes/replicaset_watch.go
@@ -108,10 +108,10 @@ func UpdateReplicaSet(objOld interface{}, objNew interface{}) {
 		return
 	}
 	rsUpdateMutex.Lock()
+	defer rsUpdateMutex.Unlock()
 	// TODO: re-implement the updated logic to reduce computation
 	DeleteReplicaSet(objOld)
 	AddReplicaSet(objNew)
-	rsUpdateMutex.Unlock()
 }
 
 func DeleteReplicaSet(obj interface{}) {

--- a/collector/pkg/metadata/kubernetes/service_watch.go
+++ b/collector/pkg/metadata/kubernetes/service_watch.go
@@ -62,17 +62,18 @@ func (s *ServiceMap) GetServiceMatchLabels(namespace string, labels map[string]s
 
 func (s *ServiceMap) add(info *K8sServiceInfo) {
 	s.mut.Lock()
+	defer s.mut.Unlock()
 	serviceNameMap, ok := s.ServiceMap[info.Namespace]
 	if !ok {
 		serviceNameMap = make(map[string]*K8sServiceInfo)
 	}
 	serviceNameMap[info.ServiceName] = info
 	s.ServiceMap[info.Namespace] = serviceNameMap
-	s.mut.Unlock()
 }
 
 func (s *ServiceMap) delete(namespace string, serviceName string) {
 	s.mut.Lock()
+	defer s.mut.Unlock()
 	serviceNameMap, ok := s.ServiceMap[namespace]
 	if ok {
 		serviceInfo, ok := serviceNameMap[serviceName]
@@ -86,7 +87,6 @@ func (s *ServiceMap) delete(namespace string, serviceName string) {
 			serviceInfo.emptySelf()
 		}
 	}
-	s.mut.Unlock()
 }
 
 func ServiceWatch(clientSet *kubernetes.Clientset, handler cache.ResourceEventHandler) {
@@ -169,10 +169,10 @@ func UpdateService(objOld interface{}, objNew interface{}) {
 		return
 	}
 	serviceUpdatedMutex.Lock()
+	defer serviceUpdatedMutex.Unlock()
 	// TODO: re-implement the updated logic to reduce computation
 	DeleteService(objOld)
 	AddService(objNew)
-	serviceUpdatedMutex.Unlock()
 }
 
 func DeleteService(obj interface{}) {

--- a/collector/pkg/metadata/metaprovider/client/client.go
+++ b/collector/pkg/metadata/metaprovider/client/client.go
@@ -76,10 +76,6 @@ func (c *Client) ListAndWatch(setup kubernetes.SetPreprocessingMetaDataCache) er
 			continue
 		}
 		c.apply(&resp)
-		if kubernetes.ReWatch {
-			kubernetes.ReWatch = false
-			break
-		}
 	}
 	return nil
 }

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -143,6 +143,18 @@ processors:
     # The default value is false. It should be enabled if the ReplicaSet
     # is used to control pods in the third-party CRD except for Deployment.
     enable_fetch_replicaset: false
+    # metadata_provider is an independent program used to collect k8sMetadata from API-server and sync with every agent
+    # whether this configuration is enabled or not does not affect the output format
+    # once enabled, agent will fetch metadata from metadata_provider instead of communicate with API-server 
+    # that can reduce the pressure on API-server and transmitting less data 
+    metadata_provider_config:
+      # confirm that metedata_provider is deployed before you enable the configuration
+      enable: false
+      # set `enable_trace` as true only if you need to debug the metadata from metadata_provider
+      # each k8sMetadata fetched from metadata_provider will be printed into console
+      enable_trace: false
+      # check service endpoint by `kubectl get endpoints metadata-provider  -n kindling``
+      endpoint: http://metadata-provider.kindling:9504
   aggregateprocessor:
     # Aggregation duration window size. The unit is second.
     ticker_interval: 5

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -149,6 +149,7 @@ processors:
     # that can reduce the pressure on API-server and transmitting less data 
     metadata_provider_config:
       # confirm that metedata_provider is deployed before you enable the configuration
+      # deploy metedata_provider by `kubectl create -f deploy/metadata-provider/metadata-provider-deploy.yml`
       enable: false
       # set `enable_trace` as true only if you need to debug the metadata from metadata_provider
       # each k8sMetadata fetched from metadata_provider will be printed into console


### PR DESCRIPTION
Add default configuration for metadata provider, not enable it by default

Metadata provider is an independent program used to collect k8sMetadata from API-server and sync with every agent.
Deploy it by `kubectl create -f deploy/metadata-provider/metadata-provider-deploy.yml`