### PR TITLE
fix: avoid affecting existing locks during cache initialization

### DIFF
--- a/collector/pkg/metadata/kubernetes/initk8s.go
+++ b/collector/pkg/metadata/kubernetes/initk8s.go
@@ -216,27 +216,39 @@ func RLockMetadataCache() {
 	MetaDataCache.pMut.RLock()
 	MetaDataCache.sMut.RLock()
 	MetaDataCache.HostPortInfo.mutex.RLock()
+	GlobalNodeInfo.mutex.RLock()
+	GlobalPodInfo.mutex.RLock()
+	GlobalRsInfo.mut.RLock()
 	podDeleteQueueMut.Lock()
 }
 
 func RUnlockMetadataCache() {
 	podDeleteQueueMut.Unlock()
+	GlobalRsInfo.mut.RUnlock()
+	GlobalPodInfo.mutex.RUnlock()
+	GlobalNodeInfo.mutex.RUnlock()
 	MetaDataCache.HostPortInfo.mutex.RUnlock()
 	MetaDataCache.sMut.RUnlock()
 	MetaDataCache.pMut.RUnlock()
 	MetaDataCache.cMut.RUnlock()
 }
 
-func RLockForSetup() {
-	MetaDataCache.cMut.RLock()
-	MetaDataCache.pMut.RLock()
-	MetaDataCache.sMut.RLock()
+func LockMetadataCache() {
+	MetaDataCache.cMut.Lock()
+	MetaDataCache.pMut.Lock()
+	MetaDataCache.sMut.Lock()
+	GlobalNodeInfo.mutex.Lock()
+	GlobalPodInfo.mutex.Lock()
+	GlobalRsInfo.mut.Lock()
 	podDeleteQueueMut.Lock()
 }
 
-func RUnlockForSetup() {
+func UnlockMetadataCache() {
 	podDeleteQueueMut.Unlock()
-	MetaDataCache.sMut.RUnlock()
-	MetaDataCache.pMut.RUnlock()
-	MetaDataCache.cMut.RUnlock()
+	GlobalRsInfo.mut.Unlock()
+	GlobalPodInfo.mutex.Unlock()
+	GlobalNodeInfo.mutex.Unlock()
+	MetaDataCache.sMut.Unlock()
+	MetaDataCache.pMut.Unlock()
+	MetaDataCache.cMut.Unlock()
 }

--- a/collector/pkg/metadata/kubernetes/k8scache.go
+++ b/collector/pkg/metadata/kubernetes/k8scache.go
@@ -303,17 +303,19 @@ func SetupCache(cache *K8sMetaDataCache, nodeMap *NodeMap, serviceMap *ServiceMa
 	if cache != nil {
 		if cache.ContainerIdInfo != nil {
 			// Recalculate local cacheMap
-			localWorkloadMap = newWorkloadMap()
-			GlobalPodInfo = newPodMap()
+			tmpLocalWorkloadMap := newWorkloadMap()
+			tmpGlobalPodInfo := newPodMap()
 			for _, containersInfo := range cache.ContainerIdInfo {
 				refPodInfo := containersInfo.RefPodInfo
-				localWorkloadMap.add(&workloadInfo{
+				tmpLocalWorkloadMap.add(&workloadInfo{
 					Namespace:    refPodInfo.Namespace,
 					WorkloadName: refPodInfo.WorkloadName,
 					WorkloadKind: refPodInfo.WorkloadKind,
 				})
-				GlobalPodInfo.add(refPodInfo)
+				tmpGlobalPodInfo.add(refPodInfo)
 			}
+			GlobalPodInfo.Info = tmpGlobalPodInfo.Info
+			localWorkloadMap.Info = tmpLocalWorkloadMap.Info
 			MetaDataCache.ContainerIdInfo = cache.ContainerIdInfo
 		}
 		if cache.HostPortInfo != nil {

--- a/collector/pkg/metadata/kubernetes/k8scache.go
+++ b/collector/pkg/metadata/kubernetes/k8scache.go
@@ -90,6 +90,12 @@ func New() *K8sMetaDataCache {
 	return c
 }
 
+func (c *K8sMetaDataCache) GetCacheContainerIdInfoSize() int {
+	c.cMut.RLock()
+	defer c.cMut.RUnlock()
+	return len(c.ContainerIdInfo)
+}
+
 func (c *K8sMetaDataCache) AddByContainerId(containerId string, resource *K8sContainerInfo) {
 	c.cMut.Lock()
 	defer c.cMut.Unlock()
@@ -292,8 +298,8 @@ func (c *K8sMetaDataCache) GetNodeNameByIp(ip string) (string, bool) {
 }
 
 func SetupCache(cache *K8sMetaDataCache, nodeMap *NodeMap, serviceMap *ServiceMap, rsMap *ReplicaSetMap) {
-	RLockForSetup()
-	defer RUnlockForSetup()
+	LockMetadataCache()
+	defer UnlockMetadataCache()
 	if cache != nil {
 		if cache.ContainerIdInfo != nil {
 			// Recalculate local cacheMap
@@ -311,7 +317,7 @@ func SetupCache(cache *K8sMetaDataCache, nodeMap *NodeMap, serviceMap *ServiceMa
 			MetaDataCache.ContainerIdInfo = cache.ContainerIdInfo
 		}
 		if cache.HostPortInfo != nil {
-			MetaDataCache.HostPortInfo = cache.HostPortInfo
+			MetaDataCache.HostPortInfo.HostPortInfo = cache.HostPortInfo.HostPortInfo
 		}
 		if cache.IpContainerInfo != nil {
 			MetaDataCache.IpContainerInfo = cache.IpContainerInfo
@@ -321,13 +327,13 @@ func SetupCache(cache *K8sMetaDataCache, nodeMap *NodeMap, serviceMap *ServiceMa
 		}
 	}
 	if nodeMap != nil {
-		GlobalNodeInfo = nodeMap
+		GlobalNodeInfo.Info = nodeMap.Info
 	}
 	if serviceMap != nil {
-		GlobalServiceInfo = serviceMap
+		GlobalServiceInfo.ServiceMap = serviceMap.ServiceMap
 	}
-	if GlobalRsInfo != nil {
-		GlobalRsInfo = rsMap
+	if rsMap != nil {
+		GlobalRsInfo.Info = rsMap.Info
 	}
 	podDeleteQueue = make([]deleteRequest, 0)
 }

--- a/collector/pkg/metadata/kubernetes/replicaset_watch.go
+++ b/collector/pkg/metadata/kubernetes/replicaset_watch.go
@@ -39,6 +39,12 @@ func newReplicaSetMap() *ReplicaSetMap {
 	}
 }
 
+func (rs *ReplicaSetMap) GetSize() int {
+	rs.mut.RLock()
+	defer rs.mut.RUnlock()
+	return len(rs.Info)
+}
+
 func (rs *ReplicaSetMap) put(key string, owner Controller) {
 	rs.mut.Lock()
 	rs.Info[key] = owner

--- a/collector/pkg/metadata/metaprovider/service/service.go
+++ b/collector/pkg/metadata/metaprovider/service/service.go
@@ -76,12 +76,10 @@ func NewMetaDataWrapper(config *Config) (*MetaDataWrapper, error) {
 						mp.ReceivedServiceEventCount.String(),
 					)
 
-					kubernetes.RLockMetadataCache()
 					log.Printf("Cached Resources Counts: Containers:%d, ReplicaSet: %d\n",
-						len(kubernetes.MetaDataCache.ContainerIdInfo),
-						len(kubernetes.GlobalRsInfo.Info),
+						kubernetes.MetaDataCache.GetCacheContainerIdInfoSize(),
+						kubernetes.GlobalRsInfo.GetSize(),
 					) // kubernetes.GlobalPodInfo.Info
-					kubernetes.RUnlockMetadataCache()
 				case <-mp.stopCh:
 					ticker.Stop()
 					return
@@ -214,6 +212,7 @@ func (s *MetaDataWrapper) ListWithSemaphore(ctx context.Context, f *ioutil.Write
 		return nil, err
 	}
 	defer sem.Release(1)
+
 	kubernetes.RLockMetadataCache()
 	defer kubernetes.RUnlockMetadataCache()
 	b, _ := s.list()


### PR DESCRIPTION
Supplementing missing locks during serialization to avoid conflicts with the Kubernetes Watcher.